### PR TITLE
Limit experience

### DIFF
--- a/wowchemy/assets/scss/custom.scss
+++ b/wowchemy/assets/scss/custom.scss
@@ -1,1 +1,5 @@
 // Override this file to add your own SCSS styling.
+[aria-expanded="false"] > .expanded,
+[aria-expanded="true"] > .collapsed {
+  display: none;
+}

--- a/wowchemy/i18n/en.yaml
+++ b/wowchemy/i18n/en.yaml
@@ -128,6 +128,12 @@
 - id: more_publications
   translation: See all publications
 
+- id: more_experience
+  translation: Show more
+
+- id: less_experience
+  translation: Show less
+
 # Contact widget
 
 - id: contact_name

--- a/wowchemy/layouts/partials/widgets/experience.html
+++ b/wowchemy/layouts/partials/widgets/experience.html
@@ -8,10 +8,16 @@
 
   {{ if $page.Params.experience }}
   {{ $exp_len := len $page.Params.experience }}
+  {{ $exp_count:= $page.Params.count }}
+  {{ if eq $exp_count 0 }}
+    {{ $exp_count = 65535 }}
+  {{ else }}
+    {{ $exp_count = $exp_count | default 5 }}
+  {{ end }}
 
   {{/* Default to user's custom order (as requested in #1761) as Hugo doesn't support multiple sorts on params. */}}
   {{ range $idx, $key := $page.Params.experience }}
-  <div class="row experience">
+  <div class="row experience {{if ge $idx $exp_count}}collapse{{end}}" {{if ge $idx $exp_count}}id="expRest"{{end}}>
     <!-- Timeline -->
     <div class="col-auto text-center flex-column d-none d-sm-flex">
       <div class="row h-50">
@@ -68,6 +74,24 @@
           {{with .description}}<div class="card-text">{{. | markdownify | emojify}}</div>{{end}}
         </div>
       </div>
+      {{ if eq $idx ( sub $exp_count 1 ) }}
+        {{ $show_archive_link := gt $exp_len $exp_count }}
+        
+        {{ if $show_archive_link }}
+          <div class="see-all">
+            <a data-toggle="collapse" href="#expRest" aria-expanded="false" aria-controls="expRest">
+              <span class="collapsed">
+                {{ i18n "more_experience" | default "Show more" | emojify }}
+                <i class="fas fa-angle-down"></i>
+              </span>
+              <span class="expanded">
+                {{ i18n "less_experience" | default "Show less" | emojify }}
+                <i class="fas fa-angle-up"></i>
+              </span>
+            </a>
+          </div>
+        {{ end }}
+      {{ end }}
     </div>
   </div>
   {{end}}


### PR DESCRIPTION
### Purpose

Allow option to limit experience cards shown on page to a given number. The page shows the requested number of cards and prints a link "Show more". If clicked, the rest of experience cards are shown, and "Show more" link turns to "Show less". If clicked on "Show less", additional cards collapse and the original number of cards is shown. 

`Fixes #2455`

### Screenshots

Collapsed view
<img width="288" alt="image" src="https://user-images.githubusercontent.com/24235395/133482352-fe91f869-1c72-443e-a783-07e6f552254d.png">

Expanded view
<img width="288" alt="image" src="https://user-images.githubusercontent.com/24235395/133482435-dd5e24f4-fc42-4ae9-a2d6-bd627acfabf0.png">

### Documentation

Requires specification of the desired number in the frontmatter of the `experience.md` file via option `count`. For example, 
``` 
count: 5
```
