### PR TITLE
Show name pronunciation in About widgets

### DIFF
--- a/wowchemy/layouts/partials/widgets/about.avatar.html
+++ b/wowchemy/layouts/partials/widgets/about.avatar.html
@@ -27,7 +27,13 @@
   {{ end }}
 
   <div class="portrait-title">
+    
+    {{if $person.anno }}
+    <h2><ruby><rb>{{ $person_page.Title }}</rb><rt>{{ $person.anno }}</rt></ruby></h2>
+    {{else}}
     <h2>{{ $person_page.Title }}</h2>
+    {{end}}
+
     {{ with $person.role }}<h3>{{ . | markdownify | emojify }}</h3>{{ end }}
 
     {{ range $person.organizations }}

--- a/wowchemy/layouts/partials/widgets/about.avatar.html
+++ b/wowchemy/layouts/partials/widgets/about.avatar.html
@@ -28,11 +28,16 @@
 
   <div class="portrait-title">
     
-    {{if $person.anno }}
-    <h2><ruby><rb>{{ $person_page.Title }}</rb><rt>{{ $person.anno }}</rt></ruby></h2>
-    {{else}}
-    <h2>{{ $person_page.Title }}</h2>
-    {{end}}
+    <h2>
+      {{- with $person.name_transliteration -}}
+        <ruby>
+          <rb>{{ $person_page.Title }}</rb>
+          <rt>{{ $person.name_transliteration }}</rt>
+        </ruby>
+      {{- else -}}
+        {{- $person_page.Title -}}
+      {{- end -}}
+    </h2>
 
     {{ with $person.role }}<h3>{{ . | markdownify | emojify }}</h3>{{ end }}
 

--- a/wowchemy/layouts/partials/widgets/about.avatar.html
+++ b/wowchemy/layouts/partials/widgets/about.avatar.html
@@ -29,10 +29,10 @@
   <div class="portrait-title">
     
     <h2>
-      {{- with $person.name_transliteration -}}
+      {{- if $person.name_pronunciation -}}
         <ruby>
           <rb>{{ $person_page.Title }}</rb>
-          <rt>{{ $person.name_transliteration }}</rt>
+          <rt>{{ $person.name_pronunciation }}</rt>
         </ruby>
       {{- else -}}
         {{- $person_page.Title -}}

--- a/wowchemy/layouts/partials/widgets/about.html
+++ b/wowchemy/layouts/partials/widgets/about.html
@@ -34,10 +34,10 @@
       <div class="portrait-title">
         
         <h2>
-          {{- with $person.name_transliteration -}}
+          {{- if $person.name_pronunciation -}}
             <ruby>
               <rb>{{ $person_page.Title }}</rb>
-              <rt>{{ $person.name_transliteration }}</rt>
+              <rt>{{ $person.name_pronunciation }}</rt>
             </ruby>
           {{- else -}}
             {{- $person_page.Title -}}

--- a/wowchemy/layouts/partials/widgets/about.html
+++ b/wowchemy/layouts/partials/widgets/about.html
@@ -33,11 +33,16 @@
 
       <div class="portrait-title">
         
-        {{if $person.anno }}
-        <h2><ruby><rb>{{ $person_page.Title }}</rb><rt>{{ $person.anno }}</rt></ruby></h2>
-        {{else}}
-        <h2>{{ $person_page.Title }}</h2>
-        {{end}}
+        <h2>
+          {{- with $person.name_transliteration -}}
+            <ruby>
+              <rb>{{ $person_page.Title }}</rb>
+              <rt>{{ $person.name_transliteration }}</rt>
+            </ruby>
+          {{- else -}}
+            {{- $person_page.Title -}}
+          {{- end -}}
+        </h2>
         
         {{ with $person.role }}<h3>{{ . | markdownify | emojify }}</h3>{{ end }}
 

--- a/wowchemy/layouts/partials/widgets/about.html
+++ b/wowchemy/layouts/partials/widgets/about.html
@@ -32,7 +32,13 @@
       {{ end }}
 
       <div class="portrait-title">
+        
+        {{if $person.anno }}
+        <h2><ruby><rb>{{ $person_page.Title }}</rb><rt>{{ $person.anno }}</rt></ruby></h2>
+        {{else}}
         <h2>{{ $person_page.Title }}</h2>
+        {{end}}
+        
         {{ with $person.role }}<h3>{{ . | markdownify | emojify }}</h3>{{ end }}
 
         {{ range $person.organizations }}


### PR DESCRIPTION
### Purpose

In CJK languages, it is natural to mark the pronunciation above the text.

Thanks for your suggestions, I added a specific structure instead of modifying content. So now this will not influence the SEO and so on.

If you specific the `anno`, it will render `<ruby></ruby>`. If you leave it blank, it doesn't cause side effects.

### Screenshots

![](https://user-images.githubusercontent.com/78157415/135794921-8d7ec71c-74e6-4083-a69c-224390a11885.png)

### Documentation

```yaml

# Display name
title: 张三
# Display pronunciation
anno: Zhang San

# Is this the primary user of the site?
superuser: true

# Role/position/tagline
role: Professor of Artificial Intelligence

# Organizations/Affiliations to show in About widget
organizations:
- name: Stanford University
  url: https://www.stanford.edu/

# Short bio (displayed in user profile at end of posts)
bio: My research interests include distributed robotics, mobile computing and programmable matter.

# Interests to show in About widget
interests:
- Artificial Intelligence
- Computational Linguistics
- Information Retrieval

# Education to show in About widget
education:
  courses:
  - course: PhD in Artificial Intelligence
    institution: Stanford University
    year: 2012
  - course: MEng in Artificial Intelligence
    institution: Massachusetts Institute of Technology
    year: 2009
  - course: BSc in Artificial Intelligence
    institution: Massachusetts Institute of Technology
    year: 2008

# Social/Academic Networking
# For available icons, see: https://wowchemy.com/docs/getting-started/page-builder/#icons
#   For an email link, use "fas" icon pack, "envelope" icon, and a link in the
#   form "mailto:your-email@example.com" or "/#contact" for contact widget.
social:
- icon: envelope
  icon_pack: fas
  link: '/#contact'
- icon: twitter
  icon_pack: fab
  link: https://twitter.com/GeorgeCushen
- icon: graduation-cap  # Alternatively, use `google-scholar` icon from `ai` icon pack
  icon_pack: fas
  link: https://scholar.google.co.uk/citations?user=sIwtMXoAAAAJ
- icon: github
  icon_pack: fab
  link: https://github.com/gcushen
- icon: linkedin
  icon_pack: fab
  link: https://www.linkedin.com/

# Link to a PDF of your resume/CV.
# To use: copy your resume to `static/uploads/resume.pdf`, enable `ai` icons in `params.toml`,
# and uncomment the lines below.
# - icon: cv
#   icon_pack: ai
#   link: uploads/resume.pdf

# Enter email to display Gravatar (if Gravatar enabled in Config)
email: ""

# Highlight the author in author lists? (true/false)
highlight_name: true

