### PR TITLE
Refactor Classic Font Set Google Fonts Syntax

### DIFF
--- a/wowchemy/data/fonts/classic.toml
+++ b/wowchemy/data/fonts/classic.toml
@@ -2,7 +2,7 @@
 name = "Classic"
 
 # Optional Google font URL
-google_fonts = "Lato:400,700|Merriweather|Roboto+Mono"
+google_fonts = "family=Lato:wght@400;700&family=Merriweather&family=Roboto+Mono"
 
 # Font families
 heading_font = "Lato"


### PR DESCRIPTION
Small update to fix an error I encountered re: Google fonts on Classic font set. Without this change Hugo raises the following ERROR when font is set to "classic" in params.yaml.

```
There is a new version of Google Fonts. Learn how to upgrade your font pack at https://wowchemy.com/docs/customization/#custom-font
Error: Error building site: logged 1 error(s)
``` 

### Purpose

The Classic font set has not been updated to match the new format required for Google fonts. Attempting to build a site locally or on Netlify now raises an error (noted above) when building. I have refactored the CSS code to fix this error.


