### PR TITLE
Support gitlab backend for netlify-cms

### DIFF
--- a/wowchemy-cms/functions/parse.html
+++ b/wowchemy-cms/functions/parse.html
@@ -4,6 +4,34 @@
 {{ end }}
 
 {{ $backend_opts := dict "branch" (site.Params.cms.branch | default "main") }}
+{{ with site.Params.cms.name }}
+{{ $name := dict "name" . }}
+{{ $backend_opts = merge $backend_opts $name }}
+{{ end }}
+{{ with site.Params.cms.repo }}
+{{ $repo := dict "repo" . }}
+{{ $backend_opts = merge $backend_opts $repo }}
+{{ end }}
+{{ with site.Params.cms.auth_type }}
+{{ $auth_type := dict "auth_type" . }}
+{{ $backend_opts = merge $backend_opts $auth_type }}
+{{ end }}
+{{ with site.Params.cms.app_id }}
+{{ $app_id := dict "app_id" . }}
+{{ $backend_opts = merge $backend_opts $app_id }}
+{{ end }}
+{{ with site.Params.cms.api_root }}
+{{ $api_root := dict "api_root" . }}
+{{ $backend_opts = merge $backend_opts $api_root }}
+{{ end }}
+{{ with site.Params.cms.base_url }}
+{{ $base_url := dict "base_url" . }}
+{{ $backend_opts = merge $backend_opts $base_url }}
+{{ end }}
+{{ with site.Params.cms.auth_endpoint }}
+{{ $auth_endpoint := dict "auth_endpoint" . }}
+{{ $backend_opts = merge $backend_opts $auth_endpoint }}
+{{ end }}
 
 {{ with site.Params.cms.publish_mode }}
   {{ $publish_mode := dict "publish_mode" . }}


### PR DESCRIPTION
### Purpose

This change adds the possibility to add a custom gitlab as backend for netlify-cms.

The configuration is handled in `config/_default/params.yml`, under the section `cms`.

### Documentation

New fields to properly configure the custom gitlab backend are available in `config/_default/params.yml`. These are: 
`name`, `repo`, `auth_type`, `app_id`, `api_root`, `base_url`, `auth_endpoint`.

An example configuration of the cms section could be:

```toml
[cms]
  name = "gitlab"
  branch = "master"
  repo = "<name>/<project>"
  auth_type = "implicit"
  app_id = "<app_id>"
  api_root = "https://<gitlab-instance-domain>/api/v4"
  base_url = "https://<gitlab-instance-domain>"
  auth_endpoint = "oauth/authorize"
```
