### PR TITLE
Gets license configuration from `footer.copyright.license`

### DIFF
--- a/wowchemy/layouts/partials/site_footer_license.html
+++ b/wowchemy/layouts/partials/site_footer_license.html
@@ -5,9 +5,9 @@
 
 {{ if ($copyright_license.enable | default false) }}
 
-  {{ $allow_commercial := .Params.copyright.license.allow_commercial | default site.Params.copyright.license.allow_commercial }}
-  {{ $allow_derivatives := .Params.copyright.license.allow_derivatives | default site.Params.copyright.license.allow_derivatives }}
-  {{ $share_alike := .Params.copyright.license.share_alike | default site.Params.copyright.license.share_alike }}
+  {{ $allow_commercial := $copyright_license.allow_commercial | default false }}
+  {{ $allow_derivatives := $copyright_license.allow_derivatives | default false }}
+  {{ $share_alike := $copyright_license.share_alike | default false }}
 
   {{ $cc_code := "by" }}
   {{ if not $allow_commercial }}

--- a/wowchemy/layouts/partials/site_footer_license.html
+++ b/wowchemy/layouts/partials/site_footer_license.html
@@ -7,7 +7,7 @@
 
   {{ $allow_commercial := $copyright_license.allow_commercial | default false }}
   {{ $allow_derivatives := $copyright_license.allow_derivatives | default false }}
-  {{ $share_alike := $copyright_license.share_alike | default false }}
+  {{ $share_alike := $copyright_license.share_alike | default true }}
 
   {{ $cc_code := "by" }}
   {{ if not $allow_commercial }}


### PR DESCRIPTION
### Purpose

Fixes issue with license configuration under `footer` in `params.yml` being ignored.

Right now to work around this issue something like:
```
footer:
  copyright:
    notice: >-
      Except as otherwise noted, this work is licensed under {license}, and code
      samples are licensed under the MIT License.
    license:
      enable: true
# work around issue with license
copyright:
  license:
    allow_derivatives: true
    share_alike: false
    allow_commercial: true
```
is needed in `params.yml`

While the following should work:
```
footer:
  copyright:
    notice: >-
      Except as otherwise noted, this work is licensed under {license}, and code
      samples are licensed under the MIT License.
    license:
      enable: true
      allow_derivatives: true
      share_alike: false
      allow_commercial: true
```