### PR TITLE
feat: address Hugo v0.92 notice RE changing behaviour of .Path

### DIFF
--- a/wowchemy/layouts/authors/list.html
+++ b/wowchemy/layouts/authors/list.html
@@ -14,7 +14,7 @@
     {{/* Show the About widget if an account exists for this user. */}}
     {{ if .File }}
       {{ $widget := "widgets/about.html" }}
-      {{ $username := (path.Base (path.Split .Path).Dir) }}{{/* Alternatively, use `index .Params.authors 0` */}}
+      {{ $username := (path.Base (path.Split .File).Dir) }}{{/* Alternatively, use `index .Params.authors 0` */}}
       {{ $params := dict "root" $ "page" . "author" $username }}
       {{ partial $widget $params }}
     {{end}}

--- a/wowchemy/layouts/authors/list.html
+++ b/wowchemy/layouts/authors/list.html
@@ -14,7 +14,7 @@
     {{/* Show the About widget if an account exists for this user. */}}
     {{ if .File }}
       {{ $widget := "widgets/about.html" }}
-      {{ $username := (path.Base (path.Split .File).Dir) }}{{/* Alternatively, use `index .Params.authors 0` */}}
+      {{ $username := (path.Base .File.Dir) }}{{/* Alternatively, use `index .Params.authors 0` */}}
       {{ $params := dict "root" $ "page" . "author" $username }}
       {{ partial $widget $params }}
     {{end}}

--- a/wowchemy/layouts/index.json
+++ b/wowchemy/layouts/index.json
@@ -27,7 +27,7 @@
 
     {{/* Correct the title and URL for author profile pages. */}}
     {{- if eq .Section "authors" -}}
-      {{- $username := path.Base (path.Split .Path).Dir -}}
+      {{- $username := path.Base (path.Split .File).Dir -}}
       {{- with site.GetPage (printf "/authors/%s" $username) -}}
         {{- $permalink = .Permalink -}}
         {{- $rel_permalink = .RelPermalink -}}

--- a/wowchemy/layouts/index.json
+++ b/wowchemy/layouts/index.json
@@ -27,7 +27,7 @@
 
     {{/* Correct the title and URL for author profile pages. */}}
     {{- if eq .Section "authors" -}}
-      {{- $username := path.Base (path.Split .File).Dir -}}
+      {{- $username := path.Base .File.Dir -}}
       {{- with site.GetPage (printf "/authors/%s" $username) -}}
         {{- $permalink = .Permalink -}}
         {{- $rel_permalink = .RelPermalink -}}

--- a/wowchemy/layouts/partials/site_head.html
+++ b/wowchemy/layouts/partials/site_head.html
@@ -53,7 +53,7 @@
   {{ $superuser_role := "" }}
   {{ range first 1 (where (where site.Pages "Section" "authors") "Params.superuser" true) }}
     {{ $superuser_name = .Title }}
-    {{ $superuser_username = path.Base (path.Split .Path).Dir }}
+    {{ $superuser_username = path.Base (path.Split .File).Dir }}
     {{ $superuser_role = .Params.role }}
   {{ end }}
   {{ $scr.Set "superuser_username" $superuser_username }}{{/* Set superuser globally for page_author.html. */}}

--- a/wowchemy/layouts/partials/site_head.html
+++ b/wowchemy/layouts/partials/site_head.html
@@ -53,7 +53,7 @@
   {{ $superuser_role := "" }}
   {{ range first 1 (where (where site.Pages "Section" "authors") "Params.superuser" true) }}
     {{ $superuser_name = .Title }}
-    {{ $superuser_username = path.Base (path.Split .File).Dir }}
+    {{ $superuser_username = path.Base .File.Dir }}
     {{ $superuser_role = .Params.role }}
   {{ end }}
   {{ $scr.Set "superuser_username" $superuser_username }}{{/* Set superuser globally for page_author.html. */}}

--- a/wowchemy/layouts/partials/widget_page.html
+++ b/wowchemy/layouts/partials/widget_page.html
@@ -89,7 +89,7 @@
   {{ end }}
 
   {{/* Fix Hugo's ContentBaseName returning wrong file base name when page section is within a bundle. */}}
-  {{ $hash_id := replace $st.File.ContentBaseName "index" (path.Base (path.Split .Path).Dir) }}
+  {{ $hash_id := replace $st.File.ContentBaseName "index" (path.Base (path.Split .File).Dir) }}
 
   {{ $widget := or $st.Params.widget "blank" }}
   {{ if eq $widget "custom" }}{{ $widget = "blank" }}{{ end }}{{/* Support legacy Custom widget */}}

--- a/wowchemy/layouts/partials/widget_page.html
+++ b/wowchemy/layouts/partials/widget_page.html
@@ -89,7 +89,7 @@
   {{ end }}
 
   {{/* Fix Hugo's ContentBaseName returning wrong file base name when page section is within a bundle. */}}
-  {{ $hash_id := replace $st.File.ContentBaseName "index" (path.Base (path.Split .File).Dir) }}
+  {{ $hash_id := replace $st.File.ContentBaseName "index" (path.Base .File.Dir) }}
 
   {{ $widget := or $st.Params.widget "blank" }}
   {{ if eq $widget "custom" }}{{ $widget = "blank" }}{{ end }}{{/* Support legacy Custom widget */}}

--- a/wowchemy/layouts/partials/widgets/people.html
+++ b/wowchemy/layouts/partials/widgets/people.html
@@ -35,7 +35,7 @@
   {{ $avatar := (.Resources.ByType "image").GetMatch "*avatar*" }}
   {{/* Get link to user's profile page. */}}
   {{ $link := "" }}
-  {{ with site.GetPage (printf "/authors/%s" (path.Base (path.Split .Path).Dir)) }}
+  {{ with site.GetPage (printf "/authors/%s" (path.Base (path.Split .File).Dir)) }}
     {{ $link = .RelPermalink }}
   {{ end }}
   <div class="col-12 col-sm-auto people-person">

--- a/wowchemy/layouts/partials/widgets/people.html
+++ b/wowchemy/layouts/partials/widgets/people.html
@@ -35,7 +35,7 @@
   {{ $avatar := (.Resources.ByType "image").GetMatch "*avatar*" }}
   {{/* Get link to user's profile page. */}}
   {{ $link := "" }}
-  {{ with site.GetPage (printf "/authors/%s" (path.Base (path.Split .File).Dir)) }}
+  {{ with site.GetPage (printf "/authors/%s" (path.Base .File.Dir)) }}
     {{ $link = .RelPermalink }}
   {{ end }}
   <div class="col-12 col-sm-auto people-person">

--- a/wowchemy/layouts/publication/single.html
+++ b/wowchemy/layouts/publication/single.html
@@ -7,7 +7,7 @@
 
 {{/* Validate Pub Type if defined */}}
 {{ if gt $pub_type (sub (len $pub_types) 1) }}
-  {{ warnf "Unknown publication type in %s" .Path }}
+  {{ warnf "Unknown publication type in %s" .File }}
   {{ $pub_type = 0 }}
 {{ end }}
 

--- a/wowchemy/layouts/publication/single.html
+++ b/wowchemy/layouts/publication/single.html
@@ -7,7 +7,7 @@
 
 {{/* Validate Pub Type if defined */}}
 {{ if gt $pub_type (sub (len $pub_types) 1) }}
-  {{ warnf "Unknown publication type in %s" .File }}
+  {{ warnf "Unknown publication type in %s" .File.Path }}
   {{ $pub_type = 0 }}
 {{ end }}
 


### PR DESCRIPTION
Based on Hugo documentation (https://gohugo.io/variables/files/) and deprecation notice from HUGO > `v0.92.0`.
It seems the solution is to replace the use of `.Path`with `.File.Path`.
Fix #2592 