### PR TITLE
Run PostCSS on vendor CSS

### DIFF
--- a/wowchemy/layouts/partials/site_head.html
+++ b/wowchemy/layouts/partials/site_head.html
@@ -101,8 +101,15 @@
     {{- $stylesheets = $stylesheets | append (resources.Get (printf "css/libs/%s.css" . ) ) -}}
   {{- end -}}
   {{ $stylesheets = $stylesheets | resources.Concat "css/vendor-bundle.css" | minify }}
+  {{- if eq (getenv "WC_POST_CSS") "true" -}}
+    {{- $stylesheets = $stylesheets | postCSS -}}
+  {{- end -}}
   {{- if hugo.IsProduction -}}
     {{- $stylesheets = $stylesheets | fingerprint "md5" -}}
+  {{- end -}}
+  {{- if eq (getenv "WC_POST_CSS") "true" -}}
+    {{/* PostProcess must be last action in the pipeline */}}
+    {{- $stylesheets = $stylesheets | resources.PostProcess -}}
   {{- end -}}
   <link rel="stylesheet" href="{{$stylesheets.RelPermalink}}" media="print" onload="this.media='all'">
 


### PR DESCRIPTION
### Purpose

Currently, PostCSS can optionally be run on the main CSS bundle. This change allows PostCSS to also be run on the vendor CSS. This can greatly reduce the size of the vendor CSS bundle when combined with PurgeCSS since most of the Font Awesome CSS is unused.

### Documentation

No documentation changes are necessary as far as I know.