### PR TITLE
fix: post list duplicated on project page

### DIFF
--- a/wowchemy/layouts/project/single.html
+++ b/wowchemy/layouts/project/single.html
@@ -22,7 +22,6 @@
         <h2>{{ (i18n "posts") }}</h2>
         {{ range $index, $item := $items }}
           {{ partial "functions/render_view" (dict "page" $ "item" . "view" (site.Params.projects.post_view | default "compact") "index" $index) }}
-          {{ partial "functions/render_view" (dict "page" $ "item" . "view" (site.Params.projects.post_view | default "compact") "index" $index) }}
         {{end}}
       {{ end }}
 


### PR DESCRIPTION

fix project list show twice