### PR TITLE
Rename cms branch param from master

### DIFF
--- a/starters/academic/config/_default/params.yaml
+++ b/starters/academic/config/_default/params.yaml
@@ -99,7 +99,7 @@ features:
 
 extensions:
   cms:
-    branch: master
+    branch: main
     local_backend: false
   academicons:
     enable: true


### PR DESCRIPTION
Github has changed from using master -> main as the default branch name for new repos. So when netlify creates a new repo based on this template, the default branch is named 'main' instead of 'master'.

Leaving this config param as 'master' will result in a credentials error whenever a user tries to login using the /admin page. Renaming this to 'main' fixes the error.

### Purpose

Describe the purpose of this change. If there is an existing issue that is resolved by this pull request, please reference it in the form `Fixes #1234` where 1234 is the relevant issue number.

### Screenshots

If this is a GUI change, try to include screenshots of the change. If not, please delete this section.

### Documentation

If this is an enhancement, add a link here to the corresponding pull request on https://github.com/sourcethemes/academic-www or describe the documentation changes necessary.
