### PR TITLE
fix module dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module github.com/wowchemy/wowchemy-hugo-modules/v5
 go 1.15
 
 require (
-  github.com/wowchemy/wowchemy-hugo-modules/wowchemy/v5 v5.0.0-20210629192904-559885af86b7
-  github.com/wowchemy/wowchemy-hugo-modules/wowchemy-cms/v5 v5.0.0-20210629192904-559885af86b7
+  github.com/wowchemy/wowchemy-hugo-themes/wowchemy/v5 v5.0.0-20210629192904-559885af86b7
+  github.com/wowchemy/wowchemy-hugo-themes/wowchemy-cms/v5 v5.0.0-20210629192904-559885af86b7
 )
 
 replace (
-  github.com/wowchemy/wowchemy-hugo-modules/wowchemy/v5 => ./wowchemy
-  github.com/wowchemy/wowchemy-hugo-modules/wowchemy-cms/v5 => ./wowchemy-cms
+  github.com/wowchemy/wowchemy-hugo-themes/wowchemy/v5 => ./wowchemy
+  github.com/wowchemy/wowchemy-hugo-themes/wowchemy-cms/v5 => ./wowchemy-cms
 )


### PR DESCRIPTION
### Purpose

Command `hugo server` fails with `Error: module "github.com/wowchemy/wowchemy-hugo-modules/wowchemy/v5" not found; either add it as a Hugo Module or store it in "/Users/georgiana/code/revamped/tekkie.ro/themes".: module does not exist` due to a rename.

### Documentation

Use proper module includes to address the above issue.
