### PR TITLE
Add Slider background fit option to cover or contain image

### DIFF
--- a/wowchemy/layouts/partials/widgets/slider.html
+++ b/wowchemy/layouts/partials/widgets/slider.html
@@ -27,9 +27,9 @@
     {{ if $item.background.media }}
       {{ $bg_img := resources.Get (printf "media/%s" $item.background.media) }}
       {{ if $bg_img }}
-        {{ $style_bg = printf "%sbackground-image: url('%s'); background-repeat: no-repeat; background-position: %s; background-size: cover; " $style_bg $bg_img.Permalink ($item.background.position | default "center") }}
+        {{ $style_bg = printf "%sbackground-image: url('%s'); background-repeat: no-repeat; background-position: %s; background-size: %s; " $style_bg $bg_img.Permalink ($item.background.position | default "center") ($item.background.media_size | default "cover")}}
       {{ else }}
-        {{ errorf "Couldn't find `%s` in the `assets/media/` folder - please add it." $item.overlay_img }}
+        {{ errorf "Couldn't find `%s` in the `assets/media/` folder - please add it." $item.background.media }}
       {{ end }}
       {{ with $item.background.brightness }}
         {{ $style_filter = printf "%s-webkit-backdrop-filter: brightness(%s); backdrop-filter: brightness(%s);" $style_filter (string .) (string .) }}

--- a/wowchemy/layouts/partials/widgets/slider.html
+++ b/wowchemy/layouts/partials/widgets/slider.html
@@ -27,7 +27,7 @@
     {{ if $item.background.media }}
       {{ $bg_img := resources.Get (printf "media/%s" $item.background.media) }}
       {{ if $bg_img }}
-        {{ $style_bg = printf "%sbackground-image: url('%s'); background-repeat: no-repeat; background-position: %s; background-size: %s; " $style_bg $bg_img.Permalink ($item.background.position | default "center") ($item.background.media_size | default "cover")}}
+        {{ $style_bg = printf "%sbackground-image: url('%s'); background-repeat: no-repeat; background-position: %s; background-size: %s; " $style_bg $bg_img.Permalink ($item.background.position | default "center") ($item.background.fit | default "cover") }}
       {{ else }}
         {{ errorf "Couldn't find `%s` in the `assets/media/` folder - please add it." $item.background.media }}
       {{ end }}


### PR DESCRIPTION
Added media_size option analagous to image_size in homepage backgrounds and fix stale reference to overlay_img.

### Purpose

Adds customizability to slider widget and fixes error.

### Documentation

Enhances https://wowchemy.com/docs/widget/slider/
Add media_size option analagous to image_size in https://wowchemy.com/docs/getting-started/page-builder/#background
"#  Options are `cover` (default), `contain`, or `actual` size."
