### PR TITLE
chore: fix lint and format warnings

### DIFF
--- a/.github/workflows/build-test-site.yaml
+++ b/.github/workflows/build-test-site.yaml
@@ -32,26 +32,10 @@ jobs:
         run: rm -rf node_modules && yarn install --frozen-lockfile
 
       - name: Check for linting errors
-        run: yarn run lint:js  # TODO: also lint styles again once new rule errors resolved
+        run: yarn run lint
 
-#  format:
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v2
-#        with:
-#          # Make sure the actual branch is checked out when running on pull requests
-#          ref: ${{ github.head_ref }}
-#
-#      - name: Prettify code
-#        uses: creyD/prettier_action@v3.1
-#        with:
-#          prettier_options: '--write wowchemy/*.{css,js,json,md,scss} wowchemy/**/*.{css,js,json,md,scss}' # Match package.json
-#          prettier_version: '2.2.1' # Match package.json
-#          commit_message: 'refactor: format code'
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check for formatting errors
+        run: yarn run format:check
 
   hugo:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "lint:style": "stylelint '*/**/*.{css,scss}'",
     "lint:style:fix": "stylelint '*/**/*.{css,scss}' --fix",
     "format": "prettier --write \"*.{css,js,json,md,scss}\" \"./**/*.{css,js,json,md,scss}\"",
+    "format:check": "prettier --check \"*.{css,js,json,md,scss}\" \"./**/*.{css,js,json,md,scss}\"",
     "stylelint-conflict-check": "stylelint-config-prettier-check",
     "update:starter": "scripts/update-starter.sh",
     "update:starters": "hugo mod get -u ./..."

--- a/starters/notes/README.md
+++ b/starters/notes/README.md
@@ -2,7 +2,7 @@
 
 [![Screenshot](./preview.webp)](https://wowchemy.com/hugo-themes/)
 
-The **Notes** starter template empowers you to easily create  **personal notes** and **knowledge bases** in a future-proof way.
+The **Notes** starter template empowers you to easily create **personal notes** and **knowledge bases** in a future-proof way.
 
 - It is your **second brain** 🧠, stored in **future-proof** Markdown files
 - Supports audio, video, images, math, code, [Mermaid](https://mermaid.live/) diagrams, and [much more](https://wowchemy.com/docs/content/writing-markdown-latex/)

--- a/starters/notes/content/_index.md
+++ b/starters/notes/content/_index.md
@@ -10,9 +10,9 @@ cover:
 
 Welcome to the _Notes_ template!
 
-The **Notes** starter template empowers you to easily create  **personal notes** and **knowledge bases** in a future-proof way.
+The **Notes** starter template empowers you to easily create **personal notes** and **knowledge bases** in a future-proof way.
 
-- It is your second brain 🧠, stored in future-proof Markdown files 
+- It is your second brain 🧠, stored in future-proof Markdown files
 - Supports audio, video, images, math, code, [Mermaid](https://mermaid.live/) diagrams, and [much more](https://wowchemy.com/docs/content/writing-markdown-latex/)
 - Edit your notes online in GitHub, or any Git-connected Markdown app such as [Obsidian](https://obsidian.md/) or [Visual Studio Code](https://vscode.dev/)
 

--- a/wowchemy-cms/README.md
+++ b/wowchemy-cms/README.md
@@ -25,7 +25,6 @@ Built upon the open source [Netlify CMS](https://www.netlifycms.org/) and [Netli
      - wowchemycms_config
      - HTML
    ---
-
    ```
 
 3. (Optional) If your Git repository's branch is **not** `main`, define it in `config/_default/params.yaml`:

--- a/wowchemy/assets/scss/wowchemy/_dark.scss
+++ b/wowchemy/assets/scss/wowchemy/_dark.scss
@@ -55,6 +55,7 @@ body.dark,
   background: rgba(233, 231, 245, 0.2);
 }
 
+// stylelint-disable-next-line selector-id-pattern
 .dark #MathJax_Zoom {
   background-color: rgb(68, 71, 90) !important;
 }

--- a/wowchemy/assets/scss/wowchemy/components/_nav.scss
+++ b/wowchemy/assets/scss/wowchemy/components/_nav.scss
@@ -7,14 +7,17 @@
   transition: transform 200ms linear;
 }
 
+// stylelint-disable-next-line selector-class-pattern
 .headroom--pinned {
   transform: translateY(0%);
 }
 
+// stylelint-disable-next-line selector-class-pattern
 .headroom--unpinned {
   transform: translateY(-100%);
 }
 
+// stylelint-disable-next-line selector-class-pattern
 .header--fixed {
   position: fixed;
   z-index: 10; // previously, 1030

--- a/wowchemy/assets/scss/wowchemy/components/_sharing.scss
+++ b/wowchemy/assets/scss/wowchemy/components/_sharing.scss
@@ -10,8 +10,7 @@ ul.share {
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-direction: row;
-  flex-wrap: wrap;
+  flex-flow: row wrap;
   list-style: none;
   margin: 0;
   padding: 0;

--- a/wowchemy/assets/scss/wowchemy/elements/_callout.scss
+++ b/wowchemy/assets/scss/wowchemy/elements/_callout.scss
@@ -2,6 +2,7 @@
 
 /* Style asides as Bootstrap alerts. */
 .article-style aside {
+  // stylelint-disable-next-line scss/at-extend-no-missing-placeholder
   @extend .alert;
 }
 

--- a/wowchemy/assets/scss/wowchemy/elements/_content.scss
+++ b/wowchemy/assets/scss/wowchemy/elements/_content.scss
@@ -100,10 +100,7 @@
 
   img,
   video {
-    margin-left: auto;
-    margin-right: auto;
-    margin-top: 2rem;
-    margin-bottom: 2rem;
+    margin: 2rem auto;
     padding: 0;
   }
 

--- a/wowchemy/assets/scss/wowchemy/elements/_media.scss
+++ b/wowchemy/assets/scss/wowchemy/elements/_media.scss
@@ -81,24 +81,26 @@ body:not(.dark) .img-dark {
 
 // Dynamically theme inline `svg`
 svg {
-  fill: currentColor;
+  fill: currentcolor;
 }
 
 /*************************************************
  *  Image zooming.
  **************************************************/
 
+// stylelint-disable selector-class-pattern
 .medium-zoom-overlay,
 .medium-zoom-image--opened {
   z-index: 1031; // Nav bar index +1.
 }
+// stylelint-enable selector-class-pattern
 
 /*************************************************
  *  Gallery.
  **************************************************/
 
 .gallery {
-  margin: 0.5em -4px 1.5em -4px;
+  margin: 0.5em -4px 1.5em;
   font-size: 0;
 }
 

--- a/wowchemy/assets/scss/wowchemy/elements/_table.scss
+++ b/wowchemy/assets/scss/wowchemy/elements/_table.scss
@@ -4,8 +4,8 @@
 
 /* Based on Bootstrap's `table-responsive` style. */
 table {
-  //display: block;
-  //width: 100%;
+  // display: block;
+  // width: 100%;
   overflow-x: scroll;
   margin-bottom: 1rem;
   font-size: 0.8rem;

--- a/wowchemy/assets/scss/wowchemy/helpers/_word-wrap.scss
+++ b/wowchemy/assets/scss/wowchemy/helpers/_word-wrap.scss
@@ -3,13 +3,13 @@
   overflow-wrap: break-word;
   word-wrap: break-word;
 
-  //-ms-word-break: break-all;
-  //word-break: break-all;
+  // -ms-word-break: break-all;
+  // word-break: break-all;
   word-break: break-word;
 
   // Add a hyphen where the word breaks, if supported (No Blink).
-  //-ms-hyphens: auto;
-  //-moz-hyphens: auto;
-  //-webkit-hyphens: auto;
-  //hyphens: auto;
+  // -ms-hyphens: auto;
+  // -moz-hyphens: auto;
+  // -webkit-hyphens: auto;
+  // hyphens: auto;
 }

--- a/wowchemy/assets/scss/wowchemy/layouts/_book.scss
+++ b/wowchemy/assets/scss/wowchemy/layouts/_book.scss
@@ -72,6 +72,7 @@
       z-index: 10;
       height: calc(100vh - 50px);
     }
+
     .no-navbar .docs-sidebar {
       top: 0;
       height: 100vh;
@@ -91,6 +92,7 @@
       z-index: 10;
       height: calc(100vh - 70px);
     }
+
     .no-navbar .docs-sidebar {
       top: 0;
       height: 100vh;
@@ -229,26 +231,31 @@
   padding-left: calc(1.5rem + 1px);
 }
 
+// stylelint-disable-next-line selector-id-pattern
 #TableOfContents {
   padding-left: 0;
   border-left: 1px solid #eee;
 }
 
+// stylelint-disable-next-line selector-id-pattern
 #TableOfContents ul,
 ul.toc-top {
   padding-left: 0;
 }
 
 // TOC indentation for each level.
+// stylelint-disable-next-line selector-id-pattern
 #TableOfContents ul ul {
   padding-left: 0.8rem;
 }
 
+// stylelint-disable-next-line selector-id-pattern
 #TableOfContents li {
   display: block;
   margin-bottom: 8px; // Lighthouse: tap targets must be at least 8px apart
 }
 
+// stylelint-disable-next-line selector-id-pattern
 #TableOfContents li a,
 .toc-top li a {
   display: block;
@@ -258,11 +265,13 @@ ul.toc-top {
   font-size: 16px; // Lighthouse: min tap target size
 }
 
+// stylelint-disable-next-line selector-id-pattern
 .dark #TableOfContents li a,
 .dark .toc-top li a {
   color: rgba(255, 255, 255, 0.65);
 }
 
+// stylelint-disable-next-line selector-id-pattern
 #TableOfContents li a:hover,
 .toc-top li a:hover {
   color: $sta-primary;
@@ -270,6 +279,7 @@ ul.toc-top {
 }
 
 /* ScrollSpy active link style. */
+// stylelint-disable-next-line selector-id-pattern
 #TableOfContents li a.active {
   color: $sta-primary;
   font-weight: 700;

--- a/wowchemy/assets/scss/wowchemy/layouts/_footer.scss
+++ b/wowchemy/assets/scss/wowchemy/layouts/_footer.scss
@@ -36,8 +36,7 @@ footer .powered-by {
 
 .footer-license-icons {
   display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+  flex-flow: row wrap;
   justify-content: center;
   list-style: none;
   height: auto;

--- a/wowchemy/assets/scss/wowchemy/layouts/_search.scss
+++ b/wowchemy/assets/scss/wowchemy/layouts/_search.scss
@@ -87,14 +87,17 @@
 }
 
 // Override Algolia results style
+// stylelint-disable selector-class-pattern
 .ais-Hits-item,
 .ais-InfiniteHits-item {
   background: unset;
   box-shadow: unset;
   padding: unset;
 }
+// stylelint-enable selector-class-pattern
 
 // Override Algolia search box icon style
+// stylelint-disable-next-line selector-class-pattern
 .ais-SearchBox-form::before {
   all: unset; // clear Algolia style
   height: 1rem;
@@ -218,7 +221,7 @@
 }
 
 // Algolia dark-themed search input
-
+// stylelint-disable-next-line selector-class-pattern
 .dark .ais-search-box--input {
   background-color: $sta-dark-background;
 }

--- a/wowchemy/assets/scss/wowchemy/widgets/_about.scss
+++ b/wowchemy/assets/scss/wowchemy/widgets/_about.scss
@@ -47,8 +47,7 @@
 
 ul.network-icon {
   display: inline-flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+  flex-flow: row wrap;
   justify-content: center;
   list-style: none;
   padding: 0;


### PR DESCRIPTION
This makes sure that both `yarn lint` and `yarn format` pass.

Additionally this reenables CI checks.
