### PR TITLE
fix: encoding of quotes in Page Sharer URL

### DIFF
--- a/wowchemy/layouts/partials/components/page_sharer.html
+++ b/wowchemy/layouts/partials/components/page_sharer.html
@@ -7,8 +7,14 @@
       {{ if in (slice "fab" "fas" "far" "fal") $pack }}
         {{ $pack_prefix = "fa" }}
       {{ end }}
-      {{ $link := replace .url "{url}" (replace ($.Permalink | urlquery) "+" "%20") }}
-      {{ $link = replace $link "{title}" (replace ($.Title | urlquery) "+" "%20") }}
+      {{/* Utilise `urlquery` over `htmlEscape` to encode sharing URL */}}
+      {{/* See https://github.com/wowchemy/wowchemy-hugo-themes/pull/2726 */}}
+      {{ $link := replace .url "{url}" ($.Permalink | urlquery) }}
+      {{ $link = replace $link "{title}" ($.Title | urlquery) }}
+      {{/* Workaround `urlquery` encoding for mailto as `urlquery` encodes `+` as `%2B` and ` ` (space) as `+` */}}
+      {{ if eq (urls.Parse $link).Scheme "mailto" }}
+        {{ $link = replace $link "+" "%20" }}
+      {{ end }}
       <li>
         <a href="{{$link|safeURL}}" target="_blank" rel="noopener" class="share-btn-{{.id}}" aria-label="{{.icon}}">
           <i class="{{$pack}} {{$pack_prefix}}-{{.icon}}"></i>

--- a/wowchemy/layouts/partials/components/page_sharer.html
+++ b/wowchemy/layouts/partials/components/page_sharer.html
@@ -7,8 +7,8 @@
       {{ if in (slice "fab" "fas" "far" "fal") $pack }}
         {{ $pack_prefix = "fa" }}
       {{ end }}
-      {{ $link := replace .url "{url}" ($.Permalink | htmlEscape) }}
-      {{ $link = replace $link "{title}" ($.Title | htmlEscape) }}
+      {{ $link := replace .url "{url}" (replace ($.Permalink | urlquery) "+" "%20") }}
+      {{ $link = replace $link "{title}" (replace ($.Title | urlquery) "+" "%20") }}
       <li>
         <a href="{{$link|safeURL}}" target="_blank" rel="noopener" class="share-btn-{{.id}}" aria-label="{{.icon}}">
           <i class="{{$pack}} {{$pack_prefix}}-{{.icon}}"></i>


### PR DESCRIPTION
### Purpose

Change the way url and title are encoded for sharing posts. Originally `htmlEscape` was used; however, it only escapes few characters and it breaks the generated urls.

For example, if a post title was "What's in today?", the quote `'` would be encoded as `&#39;` which broke the link.
Besides that, `htmlEscape` only tried to fix few characters.

So instead of using `htmlEscape` we should use `urlquery` which encodes all characters that are required in the string.
However, `urlquery` encodes `+` as `%2B` and ` ` (i.e., space) as `+`:
https://cs.opensource.google/go/go/+/refs/tags/go1.18.2:src/net/url/url.go;drc=7791e934c882fd103357448aee0fd577b20013ce;l=285  
Because of this `mailto` links were still having trouble with + and spaces, so we re-encode the "+spaces" into `%20`, so they decode correctly for `mailto`.
