### PR TITLE
Remove autocorrect

### DIFF
--- a/wowchemy/layouts/partials/search.html
+++ b/wowchemy/layouts/partials/search.html
@@ -17,7 +17,7 @@
       <div id="search-box">
         {{ if eq $search_provider "wowchemy" }}
         <input name="q" id="search-query" placeholder="{{i18n "search_placeholder"}}" autocapitalize="off"
-        autocomplete="off" autocorrect="off" spellcheck="false" type="search" class="form-control"
+        autocomplete="off" spellcheck="false" type="search" class="form-control"
         aria-label="{{i18n "search_placeholder"}}">
         {{ else }}
         <!-- Search box will appear here -->

--- a/wowchemy/layouts/section/publication.html
+++ b/wowchemy/layouts/section/publication.html
@@ -22,7 +22,7 @@
       <div class="form-row mb-4">
         <div class="col-auto">
           <input type="search" class="filter-search form-control form-control-sm" placeholder="{{ i18n "search_placeholder" }}" autocapitalize="off"
-          autocomplete="off" autocorrect="off" role="textbox" spellcheck="false">
+          autocomplete="off" role="textbox" spellcheck="false">
         </div>
         <div class="col-auto">
           <select class="pub-filters pubtype-select form-control form-control-sm" data-filter-group="pubtype">


### PR DESCRIPTION
### Purpose

This is in effort to eliminate HTML validator errors for rescinded methods like `autocorrect` in the search `input`

Html Validator used:
https://github.com/validator/validator

Error

```
error: Attribute “autocorrect” not allowed on element “input” at this point.
```

See Issue (now closed) #1197 
