### PR TITLE
Pass context to the hook partial

### DIFF
--- a/wowchemy/layouts/partials/functions/get_hook.html
+++ b/wowchemy/layouts/partials/functions/get_hook.html
@@ -4,12 +4,13 @@
 
 {{ $loaded := false }}
 {{ $partial_dir := printf "hooks/%s/" .hook }}
+{{ $context := .context }}
 {{ $hook_dir_path := path.Join "layouts/partials" $partial_dir }}
 {{ if fileExists $hook_dir_path }}
   {{ range os.ReadDir $hook_dir_path }}
     {{ if not .IsDir }}
       {{ $partial_path := path.Join $partial_dir .Name }}
-      {{ partial $partial_path . }}
+      {{ partial $partial_path $context }}
       {{ $loaded = true }}
     {{ end }}
   {{ end }}


### PR DESCRIPTION
### Purpose
This commit fix a bug of a context not being passed to the hook partial.

