### PR TITLE
Add docs to shortcodes

### DIFF
--- a/modules/wowchemy/layouts/shortcodes/audio.html
+++ b/modules/wowchemy/layouts/shortcodes/audio.html
@@ -2,6 +2,18 @@
 {{/* Load audio from page dir falling back to media library at `assets/media/` and then to remote URI. */}}
 {{/* Supports primarily MP3 and MP4. */}}
 
+{{/*
+    Docs: https://wowchemy.com/docs/content/writing-markdown-latex/#audio
+
+    Parameters
+    ----------
+    src :
+        Path to file or url for the audio file.
+        If a local file, first it is searched in the page directory, and then in `assets/media/` .
+    id : optional
+        Custom id "audio-{id}" to associate to the <audio> tag.
+*/}}
+
 {{ $destination := .Get "src" }}
 {{ $is_remote := strings.HasPrefix $destination "http" }}
 {{- $asset := "" -}}

--- a/modules/wowchemy/layouts/shortcodes/callout.html
+++ b/modules/wowchemy/layouts/shortcodes/callout.html
@@ -1,3 +1,14 @@
+{{/*
+    Docs: https://wowchemy.com/docs/content/writing-markdown-latex/#callouts
+
+    Parameters
+    ----------
+    #0 : optional, positional
+        Add the class "alert-{#0}" to the <div> container of the callout element.
+        Default Wowchemy available styles are "note" and "warning".
+        Otherwise you can create your own class (see `assets/scss/wowchemy/elements/_callout.scss`).
+*/}}
+
 <div class="alert alert-{{ .Get 0 }}">
   <div>
     {{ .Inner | markdownify | emojify  }}

--- a/modules/wowchemy/layouts/shortcodes/chart.html
+++ b/modules/wowchemy/layouts/shortcodes/chart.html
@@ -5,7 +5,7 @@
     ----------
     data :
         Plotly JSON file name (without ".json" extension, since it is appended automatically to the name).
-        File is searchedd in the page folder.
+        Expects the JSON file to be placed in the page folder.
 */}}
 
 {{ $json := printf "./%s.json" (.Get "data") }}

--- a/modules/wowchemy/layouts/shortcodes/chart.html
+++ b/modules/wowchemy/layouts/shortcodes/chart.html
@@ -1,3 +1,13 @@
+{{/*
+    Docs: https://wowchemy.com/docs/content/writing-markdown-latex/#charts
+
+    Parameters
+    ----------
+    data :
+        Plotly JSON file name (without ".json" extension, since it is appended automatically to the name).
+        File is searchedd in the page folder.
+*/}}
+
 {{ $json := printf "./%s.json" (.Get "data") }}
 {{ $id := delimit (shuffle (seq 1 9)) "" }}
 <div id="chart-{{$id}}" class="chart"></div>

--- a/modules/wowchemy/layouts/shortcodes/cite.html
+++ b/modules/wowchemy/layouts/shortcodes/cite.html
@@ -1,3 +1,21 @@
+{{/*
+    Docs: https://wowchemy.com/docs/content/writing-markdown-latex/#cite
+
+    Parameters
+    ----------
+    page : optional
+        Path to folder or page to be referenced.
+        It defaults to current page.
+    view : default "2"
+        Must be one of ["1", "2", "3", "4"].
+        Defines one of the available listing views in Wowchemy:
+        1. Stream
+        2. Compact
+        3. Card
+        4. Traditional
+        It defaults to compact view.
+*/}}
+
 {{ $page := .Page }}
 {{ $item := .Get "page" }}
 

--- a/modules/wowchemy/layouts/shortcodes/cite.html
+++ b/modules/wowchemy/layouts/shortcodes/cite.html
@@ -3,17 +3,10 @@
 
     Parameters
     ----------
-    page : optional
-        Path to folder or page to be referenced.
-        It defaults to current page.
-    view : default "2"
-        Must be one of ["1", "2", "3", "4"].
-        Defines one of the available listing views in Wowchemy:
-        1. Stream
-        2. Compact
-        3. Card
-        4. Traditional
-        It defaults to compact view.
+    page : required
+        Path to Markdown page to be referenced.
+    view : optional, default "compact"
+        A built-in Wowchemy view or an installed community view.
 */}}
 
 {{ $page := .Page }}

--- a/modules/wowchemy/layouts/shortcodes/cta.html
+++ b/modules/wowchemy/layouts/shortcodes/cta.html
@@ -1,3 +1,22 @@
+{{/*
+    Docs: https://wowchemy.com/docs/content/writing-markdown-latex/#call-to-action-buttons
+
+    Parameters
+    ----------
+    cta_text :
+        Text to display in the CTA button.
+    cta_link :
+        Link to action when CTA button is clicked.
+    cta_new_tab : default "false"
+        If "true", open the link in a new tab.
+    cta_alt_text : optional
+        Alternate text to display in the CTA button.
+    cta_alt_link : optional
+       Link to alternative action when CTA button is clicked.
+    cta_alt_new_tab : optional, default "false"
+        If "true", open the alternative link in a new tab.
+*/}}
+
 <ul class="cta-group">
   {{ if (.Get "cta_text") }}
   <li>

--- a/modules/wowchemy/layouts/shortcodes/emoji_list.html
+++ b/modules/wowchemy/layouts/shortcodes/emoji_list.html
@@ -1,1 +1,5 @@
+{{/*
+    Docs: https://wowchemy.com/docs/content/writing-markdown-latex/#emojis
+*/}}
+
 <div class="emoji-list">{{ .Inner }}</div>

--- a/modules/wowchemy/layouts/shortcodes/figure.html
+++ b/modules/wowchemy/layouts/shortcodes/figure.html
@@ -14,17 +14,16 @@
     caption : optional
         Caption to add to the figure.
     title : optional
-        Legacy alias for 'caption'.
+        DEPRECATED. Legacy alias for 'caption'.
     lightbox : default "true"
-        If 'lightbox' is "true" and no 'link' is sepcified, the figure is made zoomable.
+        If 'lightbox' is "true" and no 'link' is specified, the figure is made zoomable.
     link : optional
-        Link to open on click.
-        If 'lightbox' is "true" and no 'link' is sepcified, the figure is made zoomable.
+        Link to open on click instead of zooming on click.
     id : optional
         Custom id "figure-{id}" to associate to the <figure> tag.
-        It deafults to 'caption'.
+        The id defaults to the caption if unset.
     alt : optional
-        Alternate text for the image. It defaults to 'caption'.
+        Screen reader text. Defaults to the caption if unset.
     theme : optional
         One of ["light", "dark"]. Respectively adds the class ["img-light", "img-dark"] to <figure>.
         If "light", image is inverted when browsing in dark mode; the opposite otherwise.

--- a/modules/wowchemy/layouts/shortcodes/figure.html
+++ b/modules/wowchemy/layouts/shortcodes/figure.html
@@ -3,6 +3,44 @@
 {{/* Note: Uses `{{-` to unindent HTML so that Figure shortcode can be nested within a `{{%` Markdown shortcode,
      such as Callout, without the HTML being rendered as a Markdown code block. */}}
 
+{{/*
+    Docs: https://wowchemy.com/docs/content/writing-markdown-latex/#single-image
+
+    Parameters
+    ----------
+    src :
+        Path to file or url for the image.
+        If a local file, first it is searched in the page directory, and then in `assets/media/` .
+    caption : optional
+        Caption to add to the figure.
+    title : optional
+        Legacy alias for 'caption'.
+    lightbox : default "true"
+        If 'lightbox' is "true" and no 'link' is sepcified, the figure is made zoomable.
+    link : optional
+        Link to open on click.
+        If 'lightbox' is "true" and no 'link' is sepcified, the figure is made zoomable.
+    id : optional
+        Custom id "figure-{id}" to associate to the <figure> tag.
+        It deafults to 'caption'.
+    alt : optional
+        Alternate text for the image. It defaults to 'caption'.
+    theme : optional
+        One of ["light", "dark"]. Respectively adds the class ["img-light", "img-dark"] to <figure>.
+        If "light", image is inverted when browsing in dark mode; the opposite otherwise.
+    class : optional
+        Optional additional class for <figure>.
+    max_width : optional
+        `max-width` style attribute for the <div class="w-100"> tage inside <figure>.
+        For example, "fit-content" makes the <div> of the same width of the contained image.
+    width : optional
+        `width` attribute of <img>. It defaults to image width.
+    height : optional
+        `height` attribute of <img>. It defaults to image height.
+    numbered : default "false"
+        If "true", the caption is numbered.
+*/}}
+
 {{ $destination := .Get "src" }}
 {{ $is_remote := strings.HasPrefix $destination "http" }}
 {{ $caption := .Get "caption" | default (.Get "title") | default "" }}{{/* Support legacy `title` option. */}}

--- a/modules/wowchemy/layouts/shortcodes/gallery.html
+++ b/modules/wowchemy/layouts/shortcodes/gallery.html
@@ -8,9 +8,9 @@
     Parameters
     ----------
     album : default "gallery"
-        Album folder in `assets/media/albums/` to search the images in.
+        Album folder in `assets/media/albums/` to load images from.
     order : default "asc"
-        One of ["asc", "desc"]. Sorting order by image Name.
+        Sort images by title ascending (asc) or descending (desc).
     resize_options : default "750x750"
         Resize options passed to Hugo `.Fit` function (https://gohugo.io/content-management/image-processing/).
 */}}

--- a/modules/wowchemy/layouts/shortcodes/gallery.html
+++ b/modules/wowchemy/layouts/shortcodes/gallery.html
@@ -2,6 +2,19 @@
 {{/* Load gallery images from media library. */}}
 {{/* https://github.com/wowchemy/wowchemy-hugo-themes */}}
 
+{{/*
+    Docs: https://wowchemy.com/docs/content/writing-markdown-latex/#image-gallery
+
+    Parameters
+    ----------
+    album : default "gallery"
+        Album folder in `assets/media/albums/` to search the images in.
+    order : default "asc"
+        One of ["asc", "desc"]. Sorting order by image Name.
+    resize_options : default "750x750"
+        Resize options passed to Hugo `.Fit` function (https://gohugo.io/content-management/image-processing/).
+*/}}
+
 {{/* Get album folder or default to `media/albums/gallery/`. */}}
 {{ $album := (.Get "album") | default "gallery" }}
 {{ $album_path := path.Join "media" "albums" $album "*" }}

--- a/modules/wowchemy/layouts/shortcodes/gdocs.html
+++ b/modules/wowchemy/layouts/shortcodes/gdocs.html
@@ -1,3 +1,12 @@
+{{/*
+    Docs: https://wowchemy.com/docs/content/writing-markdown-latex/#embed-documents
+
+    Parameters
+    ----------
+    src : str
+        Google Docs URL for embedding.
+*/}}
+
 <div class="responsive-wrap">
   <iframe src="{{ .Get "src" }}" frameborder="0" width="960" height="569" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
 </div>

--- a/modules/wowchemy/layouts/shortcodes/hl.html
+++ b/modules/wowchemy/layouts/shortcodes/hl.html
@@ -1,1 +1,5 @@
+{{/*
+    Docs: https://wowchemy.com/docs/content/writing-markdown-latex/#highlight-quote
+*/}}
+
 <mark>{{ .Inner | markdownify | emojify }}</mark>

--- a/modules/wowchemy/layouts/shortcodes/icon.html
+++ b/modules/wowchemy/layouts/shortcodes/icon.html
@@ -1,3 +1,18 @@
+{{/*
+    Docs: https://wowchemy.com/docs/content/writing-markdown-latex/#inline-image
+
+    Parameters
+    ----------
+    name :
+        Icon name.
+    pack : default "fas"
+        Icon pack.
+    padding_left : default "0"
+        Left padding.
+    padding_right : default "1"
+        Right padding.
+*/}}
+
 {{- if (.Get "name") -}}
   {{- $icon := .Get "name" -}}
   {{- $pack := or (.Get "pack") "fas" -}}

--- a/modules/wowchemy/layouts/shortcodes/list_categories.html
+++ b/modules/wowchemy/layouts/shortcodes/list_categories.html
@@ -1,3 +1,7 @@
+{{/*
+    Docs: https://wowchemy.com/docs/content/writing-markdown-latex/#tags-and-categories
+*/}}
+
 <ul class="list-unstyled">
   {{ range site.Taxonomies.categories }}
   <li><a href="{{.Page.RelPermalink}}">{{.Page.Title}}</a></li>

--- a/modules/wowchemy/layouts/shortcodes/list_children.html
+++ b/modules/wowchemy/layouts/shortcodes/list_children.html
@@ -1,3 +1,12 @@
+{{/*
+    Docs: https://wowchemy.com/docs/content/writing-markdown-latex/#list-child-pages
+
+    Parameters
+    ----------
+    show_summary : bool, default "false"
+        If "true", show also the summary in addition to the title.
+*/}}
+
 {{ $show_summary := ne (.Get "show_summary") "false" }}
 {{ if gt (len $.Page.Pages) 0}}
   <ul class="list-unstyled">

--- a/modules/wowchemy/layouts/shortcodes/list_tags.html
+++ b/modules/wowchemy/layouts/shortcodes/list_tags.html
@@ -1,3 +1,7 @@
+{{/*
+    Docs: https://wowchemy.com/docs/content/writing-markdown-latex/#tags-and-categories
+*/}}
+
 <ul class="list-unstyled">
   {{ range site.Taxonomies.tags }}
   <li><a href="{{.Page.RelPermalink}}">{{.Page.Title}}</a></li>

--- a/modules/wowchemy/layouts/shortcodes/math.html
+++ b/modules/wowchemy/layouts/shortcodes/math.html
@@ -1,1 +1,5 @@
+{{/*
+    Docs: https://wowchemy.com/docs/content/writing-markdown-latex/#math
+*/}}
+
 {{ .Inner }}

--- a/modules/wowchemy/layouts/shortcodes/mention.html
+++ b/modules/wowchemy/layouts/shortcodes/mention.html
@@ -1,3 +1,12 @@
+{{/*
+    Docs: https://wowchemy.com/docs/content/writing-markdown-latex/#mention-a-user
+
+    Parameters
+    ----------
+    #0 : positional
+        User account in Wowchemy to mention.
+*/}}
+
 {{- $username := .Get 0 -}}
 {{- $username_url := $username | urlize -}}
 {{- $taxonomy := "authors" -}}

--- a/modules/wowchemy/layouts/shortcodes/spoiler.html
+++ b/modules/wowchemy/layouts/shortcodes/spoiler.html
@@ -1,3 +1,16 @@
+{{/*
+    Docs: https://wowchemy.com/docs/content/writing-markdown-latex/#toggle-list
+
+    Parameters
+    ----------
+    text :
+        Spoiler title.
+    class : optional
+        Additional class for <details> tag.
+    style : optional
+        Additional style for <details> tag.
+*/}}
+
 {{- $id := printf "spoiler-%d" .Ordinal -}}
 
 <details class="spoiler {{ .Get "class" }}" {{ with .Get "style" }}style="{{ . | safeCSS }}"{{ end }} id="{{$id}}">

--- a/modules/wowchemy/layouts/shortcodes/staticref.html
+++ b/modules/wowchemy/layouts/shortcodes/staticref.html
@@ -5,9 +5,7 @@
     #0 : positional
         URL for the link (if local path, it is relative to the page folder).
     #1 : optional, positional
-        Pass for instace "newtab" as second argument to open the link in a new tab.
-        The content of the second parameter does not matter;
-        if there are 2 parametrs, the link is opened in a new tab.
+        Pass "newtab" as the second argument to open the link in a new tab.
 */}}
 
 <a href="{{ .Get 0 | relURL }}"{{ if len .Params | eq 2 }} target="_blank"{{ end }}>{{ .Inner }}</a>

--- a/modules/wowchemy/layouts/shortcodes/staticref.html
+++ b/modules/wowchemy/layouts/shortcodes/staticref.html
@@ -1,1 +1,13 @@
+{{/*
+    Docs: https://wowchemy.com/docs/content/writing-markdown-latex/#link-to-a-page
+    Parameters
+    ----------
+    #0 : positional
+        URL for the link (if local path, it is relative to the page folder).
+    #1 : optional, positional
+        Pass for instace "newtab" as second argument to open the link in a new tab.
+        The content of the second parameter does not matter;
+        if there are 2 parametrs, the link is opened in a new tab.
+*/}}
+
 <a href="{{ .Get 0 | relURL }}"{{ if len .Params | eq 2 }} target="_blank"{{ end }}>{{ .Inner }}</a>

--- a/modules/wowchemy/layouts/shortcodes/table.html
+++ b/modules/wowchemy/layouts/shortcodes/table.html
@@ -10,9 +10,9 @@
     src :
         Path or url to the csv table. Path is relative to the folder where the shortcode is called.
     delimiter : default ","
-        Cell delimiter. It must be a single character.
+        Field delimiter.
     header : default "true"
-        If "true", first row is interpreted as the header.
+        If "true", the first row is rendered as the header.
     caption : optional
         Caption for the table.
 */}}

--- a/modules/wowchemy/layouts/shortcodes/table.html
+++ b/modules/wowchemy/layouts/shortcodes/table.html
@@ -2,6 +2,21 @@
 {{/* Load a CSV table from page dir falling back back to remote URL */}}
 {{/* Defaults to expecting a comma-separated CSV with a header row. */}}
 
+{{/*
+    Docs: https://wowchemy.com/docs/content/writing-markdown-latex/#csv-table
+
+    Parameters
+    ----------
+    src :
+        Path or url to the csv table. Path is relative to the folder where the shortcode is called.
+    delimiter : default ","
+        Cell delimiter. It must be a single character.
+    header : default "true"
+        If "true", first row is interpreted as the header.
+    caption : optional
+        Caption for the table.
+*/}}
+
 {{ $src := .Get "path" }}
 {{ $delimiter := .Get "delimiter" | default "," }}
 {{ $useHeaderRow := (eq (lower (.Get "header")) "true") | default true }}

--- a/modules/wowchemy/layouts/shortcodes/toc.html
+++ b/modules/wowchemy/layouts/shortcodes/toc.html
@@ -1,3 +1,16 @@
+{{/*
+    Docs: https://wowchemy.com/docs/content/writing-markdown-latex/#table-of-contents
+
+    Parameters
+    ----------
+    hide_on : optional
+        Hide TOC for a certain screen size.
+        For instance, with `hide_on="xl"`,
+        the in page TOC only appears when the right sidebar of the book layout is hidden.
+    show_on : optional
+        Same as above, but for showing the TOC only on certain screen size.
+*/}}
+
 <details class="toc-inpage d-print-none {{with .Get "hide_on"}}d-{{.}}-none{{end}} {{with .Get "show_on"}}d-none d-{{.}}-block{{end}}" open>
   <summary class="font-weight-bold">{{ i18n "table_of_contents" }}</summary>
   {{ $.Page.TableOfContents }}

--- a/modules/wowchemy/layouts/shortcodes/video.html
+++ b/modules/wowchemy/layouts/shortcodes/video.html
@@ -1,6 +1,25 @@
 {{/* Video Shortcode for Wowchemy. */}}
 {{/* Load video from page dir falling back to media library at `assets/media/` and then to remote URI. */}}
 
+{{/*
+    Docs: https://wowchemy.com/docs/content/writing-markdown-latex/#videos
+
+    Parameters
+    ----------
+    src :
+        Path to file or url for the video file.
+        If a local file, first it is searched in the page directory, and then in `assets/media/` .
+    poster : optional
+        Path or url for the preview image.
+        Defaults to {src without file extension}.jpg .
+        If not found, defaults to "".
+    controls : optional
+        If present, display video controls, otherwise the video is set to autoplay.
+        As default, it is not present, so the video is set to autoplay.
+    id : optional
+        Custom id "video-{id}" to associate to the <video> tag.
+*/}}
+
 {{ $destination := .Get "src" }}
 {{ $video_ext_with_dot := path.Ext (.Get "src") }}
 {{ $video_ext := strings.TrimPrefix "." $video_ext_with_dot }}

--- a/modules/wowchemy/layouts/shortcodes/video.html
+++ b/modules/wowchemy/layouts/shortcodes/video.html
@@ -15,7 +15,6 @@
         If not found, defaults to "".
     controls : optional
         If present, display video controls, otherwise the video is set to autoplay.
-        As default, it is not present, so the video is set to autoplay.
     id : optional
         Custom id "video-{id}" to associate to the <video> tag.
 */}}


### PR DESCRIPTION
### Purpose

Add shortcode parametrs documentation in the html files.

### Documentation

Add the description of shortcode parameters at the top of each file, in order to have a more immediate view of all the options availables. The format is inspired by Python docstrings.

The change should be non-breaking, since only comments are added in the file, while the code is untouched.