### PR TITLE
Fixed the Privacy link (issue: 2282)

### DIFF
--- a/modules/wowchemy/layouts/partials/cookie_consent.html
+++ b/modules/wowchemy/layouts/partials/cookie_consent.html
@@ -24,7 +24,7 @@
         "message": {{ i18n "cookie_message" | default "This website uses cookies to ensure you get the best experience on our website." }},
         "dismiss": {{ i18n "cookie_dismiss" | default "Got it!" }},
         "link": {{ i18n "cookie_learn" | default "Learn more" }},
-        "href": {{ with site.GetPage "privacy.md" }}{{ printf "%s" .RelPermalink }}{{ else }}"https://www.cookiesandyou.com"{{ end }}
+        "href": {{ with site.GetPage "/privacy.md" }}{{ printf "%s" .RelPermalink }}{{ else }}"https://www.cookiesandyou.com"{{ end }}
       }
     })});
   </script>


### PR DESCRIPTION
### Purpose

Fixes #2282. Although the issue with the invalid Privacy link was reported for the site footer, it also exists in the cookie consent popup as I observed earlier in https://github.com/wowchemy/wowchemy-hugo-themes/issues/2282#issuecomment-1128348907.

### Documentation

The response from the Hugo team with respect to the issue (https://github.com/gohugoio/hugo/issues/8494) is that `.GetPage` and not `site.GetPage` should be used in this context. Hugo does not see it as a problem they need to fix.
