### PR TITLE
Fix misspelled partial name

### DIFF
--- a/modules/wowchemy/layouts/partials/jsonld/event.html
+++ b/modules/wowchemy/layouts/partials/jsonld/event.html
@@ -1,6 +1,6 @@
 {{ $page := .page }}
 {{ $summary := .summary }}
-{{ $featured_image := partial "funcctions/get_featured_image.html" $page }}
+{{ $featured_image := partial "functions/get_featured_image.html" $page }}
 {{ $author := partial "functions/get_author_name" $page }}
 
 <script type="application/ld+json">


### PR DESCRIPTION
The partial name misspelled the word "functions" as "funcctions". This caused an error when running the latest build. The error was introduced in #2799.

