### PR TITLE
Implemented Giscus commenting module and modified params.yaml for all starters

### DIFF
--- a/modules/wowchemy/layouts/partials/comments/giscus.html
+++ b/modules/wowchemy/layouts/partials/comments/giscus.html
@@ -1,0 +1,14 @@
+{{ if site.Params.features.comment.giscus }}
+<script src="https://giscus.app/client.js"
+        data-repo="{{site.Params.features.comment.giscus.repo}}"
+        data-repo-id="{{site.Params.features.comment.giscus.repo_id}}"
+        data-category="{{site.Params.features.comment.giscus.category}}"
+        data-category-id="{{site.Params.features.comment.giscus.category_id}}"
+        data-mapping="{{site.Params.features.comment.giscus.mapping}}"
+        data-reactions-enabled="{{site.Params.features.comment.giscus.reactions_enabled}}"
+        data-theme="{{site.Params.features.comment.giscus.theme}}"
+        crossorigin="anonymous"
+        async>
+</script>
+<noscript>Please enable JavaScript to view the comments powered by giscus.</noscript>
+{{ end }}

--- a/starters/academic/config/_default/params.yaml
+++ b/starters/academic/config/_default/params.yaml
@@ -81,6 +81,14 @@ features:
       show_count: true
     commento:
       url: ''
+    giscus:
+      repo: ''
+      repo_id: ''
+      category: ''
+      category_id: ''
+      mapping: ''
+      theme: ''
+      reactions_enabled: ''
   search:
     provider: wowchemy
     algolia:

--- a/starters/academic/config/_default/params.yaml
+++ b/starters/academic/config/_default/params.yaml
@@ -86,9 +86,6 @@ features:
       repo_id: ''
       category: ''
       category_id: ''
-      mapping: ''
-      theme: ''
-      reactions_enabled: ''
   search:
     provider: wowchemy
     algolia:

--- a/starters/blog/config/_default/params.yaml
+++ b/starters/blog/config/_default/params.yaml
@@ -78,6 +78,14 @@ features:
       show_count: true
     commento:
       url: ''
+    giscus:
+      repo: ''
+      repo_id: ''
+      category: ''
+      category_id: ''
+      mapping: ''
+      theme: ''
+      reactions_enabled: ''
   search:
     provider: wowchemy
     algolia:

--- a/starters/blog/config/_default/params.yaml
+++ b/starters/blog/config/_default/params.yaml
@@ -83,9 +83,6 @@ features:
       repo_id: ''
       category: ''
       category_id: ''
-      mapping: ''
-      theme: ''
-      reactions_enabled: ''
   search:
     provider: wowchemy
     algolia:

--- a/starters/course/config/_default/params.yaml
+++ b/starters/course/config/_default/params.yaml
@@ -77,6 +77,14 @@ features:
       show_count: true
     commento:
       url: ''
+    giscus:
+      repo: ''
+      repo_id: ''
+      category: ''
+      category_id: ''
+      mapping: ''
+      theme: ''
+      reactions_enabled: ''
   search:
     provider: wowchemy
     algolia:

--- a/starters/course/config/_default/params.yaml
+++ b/starters/course/config/_default/params.yaml
@@ -82,9 +82,6 @@ features:
       repo_id: ''
       category: ''
       category_id: ''
-      mapping: ''
-      theme: ''
-      reactions_enabled: ''
   search:
     provider: wowchemy
     algolia:

--- a/starters/documentation/config/_default/params.yaml
+++ b/starters/documentation/config/_default/params.yaml
@@ -84,9 +84,6 @@ features:
       repo_id: ''
       category: ''
       category_id: ''
-      mapping: ''
-      theme: ''
-      reactions_enabled: ''
   search:
     provider: wowchemy
     algolia:

--- a/starters/documentation/config/_default/params.yaml
+++ b/starters/documentation/config/_default/params.yaml
@@ -79,6 +79,14 @@ features:
       show_count: true
     commento:
       url: ''
+    giscus:
+      repo: ''
+      repo_id: ''
+      category: ''
+      category_id: ''
+      mapping: ''
+      theme: ''
+      reactions_enabled: ''
   search:
     provider: wowchemy
     algolia:

--- a/starters/minimal/config/_default/params.yaml
+++ b/starters/minimal/config/_default/params.yaml
@@ -80,6 +80,14 @@ features:
       show_count: true
     commento:
       url: ''
+    giscus:
+      repo: ''
+      repo_id: ''
+      category: ''
+      category_id: ''
+      mapping: ''
+      theme: ''
+      reactions_enabled: ''
   search:
     provider: wowchemy
     algolia:

--- a/starters/minimal/config/_default/params.yaml
+++ b/starters/minimal/config/_default/params.yaml
@@ -85,9 +85,6 @@ features:
       repo_id: ''
       category: ''
       category_id: ''
-      mapping: ''
-      theme: ''
-      reactions_enabled: ''
   search:
     provider: wowchemy
     algolia:

--- a/starters/notes/config/_default/params.yaml
+++ b/starters/notes/config/_default/params.yaml
@@ -75,6 +75,14 @@ features:
       show_count: true
     commento:
       url: ''
+    giscus:
+      repo: ''
+      repo_id: ''
+      category: ''
+      category_id: ''
+      mapping: ''
+      theme: ''
+      reactions_enabled: ''
   search:
     provider: wowchemy
     algolia:

--- a/starters/notes/config/_default/params.yaml
+++ b/starters/notes/config/_default/params.yaml
@@ -80,9 +80,6 @@ features:
       repo_id: ''
       category: ''
       category_id: ''
-      mapping: ''
-      theme: ''
-      reactions_enabled: ''
   search:
     provider: wowchemy
     algolia:

--- a/starters/portfolio/config/_default/params.yaml
+++ b/starters/portfolio/config/_default/params.yaml
@@ -85,9 +85,6 @@ features:
       repo_id: ''
       category: ''
       category_id: ''
-      mapping: ''
-      theme: ''
-      reactions_enabled: ''
   search:
     provider: ''
     algolia:

--- a/starters/portfolio/config/_default/params.yaml
+++ b/starters/portfolio/config/_default/params.yaml
@@ -80,6 +80,14 @@ features:
       show_count: true
     commento:
       url: ''
+    giscus:
+      repo: ''
+      repo_id: ''
+      category: ''
+      category_id: ''
+      mapping: ''
+      theme: ''
+      reactions_enabled: ''
   search:
     provider: ''
     algolia:

--- a/starters/research-group/config/_default/params.yaml
+++ b/starters/research-group/config/_default/params.yaml
@@ -88,9 +88,6 @@ features:
       repo_id: ''
       category: ''
       category_id: ''
-      mapping: ''
-      theme: ''
-      reactions_enabled: ''
   search:
     provider: wowchemy
     algolia:

--- a/starters/research-group/config/_default/params.yaml
+++ b/starters/research-group/config/_default/params.yaml
@@ -83,6 +83,14 @@ features:
       show_count: true
     commento:
       url: ''
+    giscus:
+      repo: ''
+      repo_id: ''
+      category: ''
+      category_id: ''
+      mapping: ''
+      theme: ''
+      reactions_enabled: ''
   search:
     provider: wowchemy
     algolia:


### PR DESCRIPTION
### Purpose
Fixes #2826. I added `giscus.html` to `modules/wowchemy/layouts/partials/comments` to enable Giscus. This solution is adapted from the one provided by @zyrikby in [his article](https://zhauniarovich.com/post/2021/2021-06-giscus/), which was based on an older version of Wowchemy starters. 

### Finished action items in #2826

- [x] Define a data structure for the most important Giscus options in params.yaml
- [x]  Implement Giscus commenting module, such as in https://github.com/wowchemy/wowchemy-hugo-themes/tree/main/modules/wowchemy/layouts/partials/comments
- [ ] Document new params.yaml Giscus options for Docs site
- [x] Add the new params.yaml data structure to all the starters in https://github.com/wowchemy/wowchemy-hugo-themes/tree/main/starters


### Documentation
To enable giscus, the user needs to 
- Set up a public repository for storing comments
- Install Giscus and allow it to access the public repo for storing comments
- Decide values of Giscus parameters to use in `params.yaml` with the assistance of [Giscus webpage](https://giscus.app). 

The steps above (with more details) should be mentioned on the [documentation page](https://wowchemy.com/docs/hugo-tutorials/comments/) about adding comments, but I was not able to find the corresponding `md` file to edit. The link https://github.com/sourcethemes/academic-www in the PR template also did not work. 
