### PR TITLE
Update Academicons font library to v1.9.2

### DIFF
--- a/modules/wowchemy/data/assets.toml
+++ b/modules/wowchemy/data/assets.toml
@@ -63,8 +63,8 @@
 # CSS
 
 [css.academicons]
-  version = "1.9.1"
-  sri = "sha512-W0xM4mr6dEP9nREo7Z9z+9X70wytKvMGeDsj7ps2+xg5QPrEBXC8tAW1IFnzjR6eoJ90JmCnFzerQJTLzIEHjA=="
+  version = "1.9.2"
+  sri = "sha512-KlJCpRsLf+KKu2VQa5vmRuClRFjxc5lXO03ixZt82HZUk41+1I0bD8KBSA0fY290ayMfWYI9udIqeOWSu1/uZg=="
   url = "https://cdn.jsdelivr.net/npm/academicons@%s/css/academicons.min.css"
 [css.leaflet]
   version = "1.7.1"


### PR DESCRIPTION
### Purpose

This PR updates the Academicons font library to the latest version (v1.9.2). The latest version contains updates to some of the logos. Notably to the HAL logo that is widely use in France.