### PR TITLE
Updated theme warning messages to be more precise.

### DIFF
--- a/modules/wowchemy/layouts/partials/functions/parse_theme.html
+++ b/modules/wowchemy/layouts/partials/functions/parse_theme.html
@@ -5,12 +5,12 @@
 {{- $theme_night_index := (site.Params.appearance.theme_night | lower | replaceRE "\\s" "_") | default "minimal" -}}
 
 {{- if not (index (index site.Data.themes $theme_day_index) "light") -}}
-  {{- warnf "Theme `%s` not found at `data/themes/%s.toml`" site.Params.appearance.theme_day $theme_day_index -}}
+  {{- warnf "Light specification for theme `%s` not found at `data/themes/%s.toml`, falling back to the light specification from the `minimal` theme." site.Params.appearance.theme_day $theme_day_index -}}
   {{- $theme_day_index = "minimal" -}}
 {{ end }}
 
 {{- if not (index (index site.Data.themes $theme_night_index) "dark") -}}
-  {{- warnf "Theme `%s` not found at `data/themes/%s.toml`" site.Params.appearance.theme_night $theme_night_index -}}
+  {{- warnf "Dark specification for theme `%s` not found at `data/themes/%s.toml`, falling back to the dark specification from the `minimal` theme." site.Params.appearance.theme_night $theme_night_index -}}
   {{- $theme_night_index = "minimal" -}}
 {{ end }}
 

--- a/modules/wowchemy/layouts/partials/functions/parse_theme.html
+++ b/modules/wowchemy/layouts/partials/functions/parse_theme.html
@@ -5,12 +5,12 @@
 {{- $theme_night_index := (site.Params.appearance.theme_night | lower | replaceRE "\\s" "_") | default "minimal" -}}
 
 {{- if not (index (index site.Data.themes $theme_day_index) "light") -}}
-  {{- warnf "Light specification for theme `%s` not found at `data/themes/%s.toml`, falling back to the light specification from the `minimal` theme." site.Params.appearance.theme_day $theme_day_index -}}
+  {{- warnf "In `params.yaml`, you requested `theme_day: %s` but there is not a `light` style in `data/themes/%s.toml`. Falling back to default light style." site.Params.appearance.theme_day $theme_day_index -}}
   {{- $theme_day_index = "minimal" -}}
 {{ end }}
 
 {{- if not (index (index site.Data.themes $theme_night_index) "dark") -}}
-  {{- warnf "Dark specification for theme `%s` not found at `data/themes/%s.toml`, falling back to the dark specification from the `minimal` theme." site.Params.appearance.theme_night $theme_night_index -}}
+  {{- warnf "In `params.yaml`, you requested `theme_night: %s` but there is not a `dark` style in `data/themes/%s.toml`. Falling back to default dark style." site.Params.appearance.theme_night $theme_night_index -}}
   {{- $theme_night_index = "minimal" -}}
 {{ end }}
 


### PR DESCRIPTION
### Purpose

Based on the suggestion at https://discord.com/channels/722225264733716590/1024935456313450506/1025050134083543152, this PR makes the warning messages for missing theme specifications more specific.

As an example, the warning is as follows.

```
Theme `forest` not found at `data/themes/forest.toml`
```

As the dark specification in the `forest` theme is missing, this PR will change it to the following.
```
Dark specification for theme `forest` not found at `data/themes/forest.toml`, falling back to dark specification from the `minimal` theme.
```

A similar message will appear if the theme is missing its light specification, for example:
```
Light specification for theme `dark` not found at `data/themes/dark.toml`, falling back to light specification from the `minimal` theme.
```