### PR TITLE
Remove inline style from featured images

### DIFF
--- a/modules/wowchemy/assets/scss/wowchemy/elements/_content.scss
+++ b/modules/wowchemy/assets/scss/wowchemy/elements/_content.scss
@@ -39,11 +39,28 @@
   padding-right: 0; /* Override container padding. */
 }
 
+.featured-image-wrapper div {
+  position: relative;
+}
+
 .featured-image {
   position: relative;
   width: 100%;
   display: block;
   margin: 0 auto;
+}
+
+.featured-image-container-md {
+  max-width: 720px; /* Width of an article-container minus padding */
+  margin: 0 auto;
+}
+
+.featured-image-container {
+  margin: 0 auto;
+
+  @include media-breakpoint-up(xl) {
+    max-width: 1200px;
+  }
 }
 
 .article-header-caption {

--- a/modules/wowchemy/layouts/partials/page_header.html
+++ b/modules/wowchemy/layouts/partials/page_header.html
@@ -49,13 +49,13 @@
 {{/* Fit image to container's max width */}}
 {{ $image_container := "" }}
 {{ if eq $placement 2}}
-  {{ $image_container = "container" }}
+  {{ $image_container = "featured-image-container" }}
   {{ $image = $featured.Fit "1200x2500 webp" }}
 {{else if eq $placement 3}}
   {{ $image_container = "container-fluid" }}
   {{ $image := $featured.Fit "2560x2560 webp" }}
 {{else}}
-  {{ $image_container = "article-container" }}
+  {{ $image_container = "featured-image-container-md" }}
   {{ $image = $featured.Fit "720x2500 webp" }}
 {{end}}
 
@@ -71,8 +71,8 @@
 </div>
 
 {{/* Featured image */}}
-<div class="article-header {{$image_container}} featured-image-wrapper mt-4 mb-4" style="max-width: {{$image.Width}}px; max-height: {{$image.Height}}px;">
-  <div style="position: relative">
+<div class="article-header {{$image_container}} featured-image-wrapper mt-4 mb-4">
+  <div>
     <img src="{{ $image.RelPermalink }}" width="{{ $image.Width }}" height="{{ $image.Height }}" alt="{{ with $.Params.image.alt_text }}{{.}}{{ end }}" class="featured-image">
     {{ with $.Params.image.caption }}<span class="article-header-caption">{{ . | markdownify | emojify }}</span>{{ end }}
   </div>


### PR DESCRIPTION
### Purpose

To eliminate the use of inline style on featured images. If a website owner wants to maintain a strict CSP then the existing inline style requires a CSP hash for every unique image size. On a site with many posts this is considerable work and means a large, ever-growing CSP.

Featured images currently come with a two bits of inline style shown at the end of lines 1 and 2 below from the file `modules/wowchemy/layouts/partials/page_header.html`:

```HTML
<div class="article-header {{$image_container}} featured-image-wrapper mt-4 mb-4" style="max-width: {{$image.Width}}px; max-height: {{$image.Height}}px;">
  <div style="position: relative">
    <img src="{{ $image.RelPermalink }}" width="{{ $image.Width }}" height="{{ $image.Height }}" alt="{{ with $.Params.image.alt_text }}{{.}}{{ end }}" class="featured-image">
    {{ with $.Params.image.caption }}<span class="article-header-caption">{{ . | markdownify | emojify }}</span>{{ end }}
  </div>
```

The `style=` on the first line is particularly painful as is includes the image size and therefore hashes differently for each variation. 

In my changes I have eliminated this and added a couple of new classes that set the max width of the image where needed to maintain the exact same behaviour and appearance as before. I'm not happy to be using hard-coded pixel values but I could find no other way to do this that didn't alter appearance/behaviour. I believe the expected behaviour of a featured image is:

1. `placement=1` Full column width. Image should grow to max 720px width.
2. `placement=2` Out-set. Image should grow to max 1200px width.
3. `placement=3` Screen-width. Image always 100% width.

### Screenshots

I have tested at all breakpoints and every placement type (1, 2, 3) and the screenshots I took were identical before/after. I also tested the image load behaviour and saw no jumps in layout before and after the load.

### Documentation

I don't think this requires documentation, it is removing a concern that only affected a few and was not documented before.
