### PR TITLE
Restore card image display changed in 2d2e58d8f4d31e1fd61d2453947913e…

### DIFF
--- a/modules/wowchemy/assets/scss/wowchemy/elements/_content.scss
+++ b/modules/wowchemy/assets/scss/wowchemy/elements/_content.scss
@@ -33,6 +33,11 @@
   }
 }
 
+.article-banner-card {
+  width: 100%;
+  height: auto;
+}
+
 .featured-image-wrapper {
   position: relative;
   padding-left: 0; /* Override container padding. */

--- a/modules/wowchemy/layouts/partials/views/card.html
+++ b/modules/wowchemy/layouts/partials/views/card.html
@@ -48,7 +48,7 @@
     <a href="{{ $link }}" {{ $target | safeHTMLAttr }}>
       <div class="img-hover-zoom">
         <img src="{{ $image.RelPermalink }}" height="{{ $image.Height }}" width="{{ $image.Width }}"
-            class="article-banner" alt="{{ $item.Title }}" loading="lazy">
+            class="article-banner-card" alt="{{ $item.Title }}" loading="lazy">
       </div>
     </a>
   {{end}}


### PR DESCRIPTION
…7fa95ee53

Restores how images were displayed in the card view in release v5.5 and prior. Fixes #2797

### Purpose

This PR proposes a fix for #2797. In short, between v5.5 and v5.6 there was a change in how the featured image is displayed in the card view, particularly visible in the portfolio widget, where it also caused the cards to become uneven in size. Issue #2797 contains before and after screenshots. @Ian2020 tracked this down to a change to `.article-banner` in 2d2e58d8f4d31e1fd61d2453947913e7fa95ee53. This change restores the previous behaviour in the card view.