### PR TITLE
Reveal correctly initialized with separate params for each slide. Added math_renderer option

### DIFF
--- a/modules/wowchemy-plugin-reveal/assets/js/wowchemy-slides.js
+++ b/modules/wowchemy-plugin-reveal/assets/js/wowchemy-slides.js
@@ -9,105 +9,120 @@
   global RevealMarkdown, RevealSearch, RevealNotes, RevealMath, RevealZoom, Reveal, mermaid, RevealMenu
 */
 
-import * as params from '@params';
+export const wowchemySlides = {
+  init: (slideParams) => {
+    // Enable core slide features.
 
-// Enable core slide features.
-var enabledPlugins = [RevealMarkdown, RevealSearch, RevealNotes, RevealMath.KaTeX, RevealZoom];
+    const RevealMathPlugin = {
+      katex: RevealMath.KaTeX, 
+      mathjax2: RevealMath.MathJax2,
+      mathjax3: RevealMath.MathJax3, 
+    }
 
-const isObject = function (o) {
-  return o === Object(o) && !isArray(o) && typeof o !== 'function';
-};
+    var enabledPlugins = [
+      RevealMarkdown, 
+      RevealSearch, 
+      RevealNotes, 
+      RevealMathPlugin[slideParams?.math_renderer] ?? RevealMath.KaTeX, 
+      RevealZoom
+    ];
 
-const isArray = function (a) {
-  return Array.isArray(a);
-};
+    const isObject = function (o) {
+      return o === Object(o) && !isArray(o) && typeof o !== 'function';
+    };
 
-const toCamelCase = function (s) {
-  return s.replace(/([-_][a-z])/gi, function (term) {
-    return term.toUpperCase().replace('-', '').replace('_', '');
-  });
-};
+    const isArray = function (a) {
+      return Array.isArray(a);
+    };
 
-const keysToCamelCase = function (o) {
-  if (isObject(o)) {
-    const n = {};
+    const toCamelCase = function (s) {
+      return s.replace(/([-_][a-z])/gi, function (term) {
+        return term.toUpperCase().replace('-', '').replace('_', '');
+      });
+    };
 
-    Object.keys(o).forEach(function (k) {
-      n[toCamelCase(k)] = keysToCamelCase(o[k]);
-    });
+    const keysToCamelCase = function (o) {
+      if (isObject(o)) {
+        const n = {};
 
-    return n;
-  } else if (isArray(o)) {
-    return o.map(function (i) {
-      return keysToCamelCase(i);
-    });
-  }
+        Object.keys(o).forEach(function (k) {
+          n[toCamelCase(k)] = keysToCamelCase(o[k]);
+        });
 
-  return o;
-};
+        return n;
+      } else if (isArray(o)) {
+        return o.map(function (i) {
+          return keysToCamelCase(i);
+        });
+      }
 
-// reveal configurations can be included in front matter under slides.reveal
-var pluginOptions = {};
-if (typeof params.slides.reveal_options !== 'undefined') {
-  pluginOptions = params.slides.reveal_options;
-}
+      return o;
+    };
 
-pluginOptions = keysToCamelCase(pluginOptions);
+    // reveal configurations can be included in front matter under slides.reveal
+    var pluginOptions = {};
+    if (typeof slideParams.reveal_options !== 'undefined') {
+      pluginOptions = slideParams.reveal_options;
+    }
 
-//enable menu by default if not set
-if (typeof pluginOptions.menu_enabled === 'undefined') {
-  pluginOptions.menu_enabled = true;
-}
+    pluginOptions = keysToCamelCase(pluginOptions);
 
-// configure menu if enabled
-if (pluginOptions.menu_enabled) {
-  enabledPlugins.push(RevealMenu);
-}
+    //enable menu by default if not set
+    if (typeof pluginOptions.menu_enabled === 'undefined') {
+      pluginOptions.menu_enabled = true;
+    }
 
-pluginOptions['plugins'] = enabledPlugins;
+    // configure menu if enabled
+    if (pluginOptions.menu_enabled) {
+      enabledPlugins.push(RevealMenu);
+    }
 
-Reveal.initialize(pluginOptions);
+    pluginOptions['plugins'] = enabledPlugins;
 
-// Disable Mermaid by default.
-if (typeof params.slides.diagram === 'undefined') {
-  params.slides.diagram = false;
-}
+    Reveal.initialize(pluginOptions);
 
-// Configure Mermaid only if diagrams are enabled.
-if (params.slides.diagram) {
-  //mermaid options
-  // mermaid: front matter configuration can be used to set mermaid options
-  // You can also use directives (see mermaid documentation)
-  var mermaidOptions = {};
-  if (typeof params.slides.diagram_options !== 'undefined') {
-    mermaidOptions = params.slides.diagram_options;
-  }
+    // Disable Mermaid by default.
+    if (typeof slideParams.diagram === 'undefined') {
+      slideParams.diagram = false;
+    }
 
-  // `startOnLoad` must be false since diagrams are lazily rendered.
-  mermaidOptions['startOnLoad'] = false;
+    // Configure Mermaid only if diagrams are enabled.
+    if (slideParams.diagram) {
+      //mermaid options
+      // mermaid: front matter configuration can be used to set mermaid options
+      // You can also use directives (see mermaid documentation)
+      var mermaidOptions = {};
+      if (typeof slideParams.diagram_options !== 'undefined') {
+        mermaidOptions = slideParams.diagram_options;
+      }
 
-  mermaid.initialize(mermaidOptions);
+      // `startOnLoad` must be false since diagrams are lazily rendered.
+      mermaidOptions['startOnLoad'] = false;
 
-  // Lazily render Mermaid diagrams within Reveal.JS slides
-  // See: https://github.com/hakimel/reveal.js/issues/2863#issuecomment-1107444425
-  let renderMermaidDiagrams = function renderMermaidDiagrams(event) {
+      mermaid.initialize(mermaidOptions);
 
-    let mermaidDivs = event.currentSlide.querySelectorAll('.mermaid:not(.done)');
-    let indices = Reveal.getIndices();
-    let pageno = `${indices.h}-${indices.v}`
+      // Lazily render Mermaid diagrams within Reveal.JS slides
+      // See: https://github.com/hakimel/reveal.js/issues/2863#issuecomment-1107444425
+      let renderMermaidDiagrams = function renderMermaidDiagrams(event) {
 
-    mermaidDivs.forEach(function (mermaidDiv, i) {
+        let mermaidDivs = event.currentSlide.querySelectorAll('.mermaid:not(.done)');
+        let indices = Reveal.getIndices();
+        let pageno = `${indices.h}-${indices.v}`
 
-      let insertSvg = function (svgCode) {
-        mermaidDiv.innerHTML = svgCode;
-        mermaidDiv.classList.add('done');
+        mermaidDivs.forEach(function (mermaidDiv, i) {
+
+          let insertSvg = function (svgCode) {
+            mermaidDiv.innerHTML = svgCode;
+            mermaidDiv.classList.add('done');
+          };
+          let graphDefinition = mermaidDiv.textContent;
+          mermaid.mermaidAPI.render(`mermaid${pageno}-${i}`, graphDefinition, insertSvg);
+        });
+        Reveal.layout();
       };
-      let graphDefinition = mermaidDiv.textContent;
-      mermaid.mermaidAPI.render(`mermaid${pageno}-${i}`, graphDefinition, insertSvg);
-    });
-    Reveal.layout();
-  };
 
-  Reveal.on('ready', event => renderMermaidDiagrams(event));
-  Reveal.on('slidechanged', event => renderMermaidDiagrams(event));
+      Reveal.on('ready', event => renderMermaidDiagrams(event));
+      Reveal.on('slidechanged', event => renderMermaidDiagrams(event));
+    }
+  }
 }

--- a/modules/wowchemy-plugin-reveal/assets/js/wowchemy-slides.js
+++ b/modules/wowchemy-plugin-reveal/assets/js/wowchemy-slides.js
@@ -11,8 +11,8 @@
 
 export const wowchemySlides = {
   init: (slideParams) => {
-    // Enable core slide features.
 
+    // Enable core slide features.
     const RevealMathPlugin = {
       katex: RevealMath.KaTeX, 
       mathjax2: RevealMath.MathJax2,

--- a/modules/wowchemy-plugin-reveal/layouts/slides/baseof.html
+++ b/modules/wowchemy-plugin-reveal/layouts/slides/baseof.html
@@ -71,8 +71,12 @@
   {{ end }}
 
   {{/* Initialize slides. */}}
-  {{ $slidejs := resources.Get "js/wowchemy-slides.js" | js.Build (dict "params" (dict "slides" $.Params.slides )) }}
-  <script src="{{ $slidejs.RelPermalink }}"></script>
+  {{ $slidejs := resources.Get "js/wowchemy-slides.js" }} 
+  <script type="module">
+    import { wowchemySlides } from {{ $slidejs.RelPermalink }}
+    wowchemySlides.init({{ $.Params.slides }})
+  </script>
+
 
 </body>
 </html>


### PR DESCRIPTION
### Purpose

Fixes #2852, a problem with the `wowchemy-plugin-reveal` plugin. Up to now parameters were passed to `wowchemy-slides.js` using `js.Build` which amalgamates parameters across all slide decks. Now `baseof.html` initializes reveal on a per slide basis.

I've also added the option to choose the math renderer (KaTeX, MathJax2 or 3) by setting `math_renderer` in the slides parameters. Defaults to KaTeX.

