### PR TITLE
fix: legacy support for custom_js/custom_head

### DIFF
--- a/modules/wowchemy/layouts/partials/site_head.html
+++ b/modules/wowchemy/layouts/partials/site_head.html
@@ -208,7 +208,7 @@
 
   {{/* EXTENSIBILITY HOOK: HEAD-END */}}
   {{/* Deprecated custom_head hook */}}
-  {{ if templates.Exists "partials/custom_head" }}
+  {{ if templates.Exists "partials/custom_head.html" }}
     {{ partial "custom_head" . }}
   {{ end }}
   {{ partial "functions/get_hook" (dict "hook" "head-end" "context" .) }}

--- a/modules/wowchemy/layouts/partials/site_js.html
+++ b/modules/wowchemy/layouts/partials/site_js.html
@@ -233,7 +233,7 @@
 
 {{/* EXTENSIBILITY HOOK: BODY-END */}}
 {{/* Deprecated custom_js hook */}}
-{{ if templates.Exists "partials/custom_js" }}
+{{ if templates.Exists "partials/custom_js.html" }}
   {{ partial "custom_js" . }}
 {{ end }}
 {{ partial "functions/get_hook" (dict "hook" "body-end" "context" .) }}


### PR DESCRIPTION


### Purpose

Despite commit acd74954b5dd0a10f683744d11635bb1b1b76076 mentioning that the custom.html is still supported for now, I don't think it's being picked up at the moment. This PR resolves this issue.