### PR TITLE
fix: view-starter-dev failed to replace mods

### DIFF
--- a/scripts/view-starter-dev.sh
+++ b/scripts/view-starter-dev.sh
@@ -2,6 +2,8 @@
 
 HUGOxPARAMSxCMSxLOCAL_BACKEND=true \
 HUGO_MODULE_REPLACEMENTS="github.com/wowchemy/wowchemy-hugo-themes/modules/wowchemy/v5 -> ../../../modules/wowchemy,
+github.com/wowchemy/wowchemy-hugo-themes/modules/wowchemy-core -> ../../../modules/wowchemy-core,
+github.com/wowchemy/wowchemy-hugo-themes/modules/wowchemy-seo -> ../../../modules/wowchemy-seo,
 github.com/wowchemy/wowchemy-hugo-themes/modules/wowchemy-plugin-netlify -> ../../../modules/wowchemy-plugin-netlify,
 github.com/wowchemy/wowchemy-hugo-themes/modules/wowchemy-plugin-reveal -> ../../../modules/wowchemy-plugin-reveal,
 github.com/wowchemy/wowchemy-hugo-themes/modules/wowchemy-plugin-netlify-cms -> ../../../modules/wowchemy-plugin-netlify-cms" \


### PR DESCRIPTION
Previously running `yarn view:local <TEMPLATE>` as given in `CONTRIBUTING.md` would yield:

```
Error: module "github.com/wowchemy/wowchemy-hugo-themes/modules/wowchemy-core" not found; either add it as a Hugo Module or store it in "/home/jeppe/Code/wowchemy-hugo-themes/starters/academic/themes".: module does not exist
```
