### PR TITLE
Nicer checkboxes

### DIFF
--- a/modules/wowchemy/assets/scss/wowchemy/components/_all.scss
+++ b/modules/wowchemy/assets/scss/wowchemy/components/_all.scss
@@ -1,11 +1,12 @@
 /* Wowchemy Components */
 
+@import 'announcement_bar';
 @import 'author-card';
 @import 'breadcrumb';
 @import 'card';
+@import 'checkbox';
 @import 'modal';
 @import 'nav';
 @import 'pagination';
 @import 'sharing';
 @import 'shortcode';
-@import 'announcement_bar';

--- a/modules/wowchemy/assets/scss/wowchemy/components/_checkbox.scss
+++ b/modules/wowchemy/assets/scss/wowchemy/components/_checkbox.scss
@@ -1,0 +1,49 @@
+/*************************************************
+*  Checkbox component
+**************************************************/
+$checkbox_size: 1.2em;
+
+@mixin checkbox($color) {
+    $checkmark_color: str-replace("#{$color}", "#", "");
+    $svg_checked_box: '<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path style="fill:%23#{$checkmark_color};fill-rule:evenodd;stroke-width:1.80314;image-rendering:auto" d="M8 0a8 8 0 0 0-8 8 8 8 0 0 0 8 8 8 8 0 0 0 8-8 8 8 0 0 0-8-8Zm4.245 4.046a.5.5 0 0 1 .349.138l.698.678a.465.465 0 0 1 0 .674l-6.425 6.28a.51.51 0 0 1-.7 0l-3.46-3.38a.467.467 0 0 1 0-.676l.7-.676a.507.507 0 0 1 .698 0L6.518 9.45l5.377-5.266a.5.5 0 0 1 .35-.138z"/></svg>';
+
+    ul.task-list {
+        padding-inline-start: ($checkbox_size + 1.0em);
+        padding-bottom      : 0.5em;
+
+        >li {
+            text-indent: 0;
+
+            >input[type=checkbox] {
+                -webkit-appearance: none;
+                appearance        : none;
+
+                width : $checkbox_size;
+                height: $checkbox_size;
+
+                position: relative;
+                top     : 0.3em;
+
+                margin-left: -($checkbox_size + 0.8em);
+
+                border-radius: 50%;
+                border       : 2px solid $color;
+
+                &:checked {
+                    background-position: center;
+                    background-size: $checkbox_size;
+                    background-repeat  : no-repeat;
+                    background-image   : url('data:image/svg+xml;utf8,#{$svg_checked_box}');
+                }
+            }
+        }
+    }
+}
+
+body {
+    @include checkbox($sta-primary);
+}
+
+body.dark {
+    @include checkbox($sta-primary-dark);
+}

--- a/modules/wowchemy/assets/scss/wowchemy/elements/_icon.scss
+++ b/modules/wowchemy/assets/scss/wowchemy/elements/_icon.scss
@@ -10,23 +10,3 @@
   line-height: 1;
   position: relative;
 }
-
-// Emoji task lists
-
-.task-list input[type='checkbox']:checked {
-  appearance: initial;
-  width: 1em;
-  height: 1em;
-  border: none;
-  background: initial;
-  position: relative;
-}
-
-.task-list input[type='checkbox']:not(:checked) {
-  width: 0.9em;
-  height: 0.9em;
-}
-
-.task-list input[type='checkbox']:checked::after {
-  content: '✅';
-}

--- a/modules/wowchemy/assets/scss/wowchemy/helpers/_all.scss
+++ b/modules/wowchemy/assets/scss/wowchemy/helpers/_all.scss
@@ -1,3 +1,4 @@
 /* Wowchemy Helpers */
 
+@import 'str-replace';
 @import 'word-wrap';

--- a/modules/wowchemy/assets/scss/wowchemy/helpers/_str-replace.scss
+++ b/modules/wowchemy/assets/scss/wowchemy/helpers/_str-replace.scss
@@ -1,0 +1,15 @@
+/// Replace `$search` with `$replace` in `$string`
+/// @author Hugo Giraudel
+/// @param {String} $string - Initial string
+/// @param {String} $search - Substring to replace
+/// @param {String} $replace ('') - New value
+/// @return {String} - Updated string
+@function str-replace($string, $search, $replace: '') {
+    $index: str-index($string, $search);
+
+    @if $index {
+      @return str-slice($string, 1, $index - 1) + $replace + str-replace(str-slice($string, $index + str-length($search)), $search, $replace);
+    }
+
+    @return $string;
+  }

--- a/starters/academic/content/post/demo/index.md
+++ b/starters/academic/content/post/demo/index.md
@@ -1,0 +1,88 @@
+---
+title: Demonstration of Markdown Features
+subtitle: This will give you a quick overview of what rendered markdown looks like in Wowchemy using the Academic template. This is useful for both development and getting a quick glance at how pretty your site could potentially be!
+
+# Summary for listings and search engines
+summary: This will give you a quick overview of what rendered markdown looks like in Wowchemy using the Academic template. This is useful for both development and getting a quick glance at how pretty your site could potentially be!
+
+# Link this post with a project
+projects: []
+
+# Date published
+date: '2020-12-12T00:00:00Z'
+
+# Date updated
+lastmod: '2020-12-12T00:00:00Z'
+
+# Is this an unpublished draft?
+draft: false
+
+# Show this page in the Featured widget?
+featured: false
+
+# Featured image
+# Place an image named `featured.jpg/png` in this page's folder and customize its options here.
+image:
+  caption: 'Image credit: [**Unsplash**](https://unsplash.com/photos/CpkOjOcXdUY)'
+  focal_point: ''
+  placement: 2
+  preview_only: false
+
+authors:
+  - admin
+  - 吳恩達
+
+tags:
+  - Academic
+  - 开源
+
+categories:
+  - Demo
+  - 教程
+---
+
+## Code highlighting
+
+```python
+# Demonstration of some Python code
+import library
+
+class YetAnotherModule:
+  def __init__(self, a: str):
+    print(f"Hello world and {a}!")
+```
+
+## Lists
+
+1. This is a numbered list
+2. With 3 entries
+   1. And a cheeky subitem
+3. Tada 🎉
+
+And another list:
+
+- This is an unordered list
+- With 4 entries
+  - And some formatting
+- **Lorem**
+- _Ipsum_
+
+And a checklist:
+
+- [ ] Milk
+- [X] Eggs
+- [X] Bacon
+- [ ] Pressure washer
+
+## Typography
+
+You can have **bold** text, _italicized_ text, ~~deleted~~ text, `code` text
+
+---
+
+And you can have blockquotes:
+
+> Reputation is an idle and most false imposition;
+> oft got without merit, and lost without deserving.
+>
+> — _Shakespeare_


### PR DESCRIPTION
This PR adds (arguably) nicer checkboxes that match the aesthetic of the Wowchemy sites in both light and dark modes.

As far as I can tell the current checkbox component doesn't align correctly and does not match the color of the site.

Before:
![image](https://user-images.githubusercontent.com/1814611/198879903-cfbcd589-55a7-47c7-86ca-806988e2a710.png)
![image](https://user-images.githubusercontent.com/1814611/198879993-4306f4de-7f29-4616-9b07-e4063b6dd3d1.png)


After:
![image](https://user-images.githubusercontent.com/1814611/198879800-cb21c618-bb54-4bf7-b976-054b6f3fed32.png)
![image](https://user-images.githubusercontent.com/1814611/198880034-6a895b80-a8fb-4b3e-b5c2-4a5ffd65383a.png)


Additionally this adds a Markdown demo page to the Academic template. I think this makes sense both as a demonstration for new users and to quickly verify during development that any stylistic changes preserve a good layout.

SVG is made by yours truly, so no copyright issues.

# Discussion

I would probably prefer to have the dark-mode checkbox a lighter color, like #bbdefb, but there doesn't seem to be a color variable that's suitable at the moment. Would it perhaps be worthwhile refactoring the colors a bit, including changing `$sta-primary-light` and `$sta-primary-dark` to be configurable instead of computed? They aren't in use in a lot of places at the moment. See also #2871 