### PR TITLE
feat: add custom rel attribute for social links

### DIFF
--- a/modules/wowchemy/layouts/partials/blocks/about.avatar.html
+++ b/modules/wowchemy/layouts/partials/blocks/about.avatar.html
@@ -71,7 +71,8 @@
       {{ $link = .link | relLangURL }}
       {{ if eq (path.Ext $link) ".pdf" }}{{ $target = "target=\"_blank\" rel=\"noopener\"" }}{{ end }}
     {{ else if in (slice "http" "https") $scheme }}
-      {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
+      {{ $rel := .custom_rel | default "noopener" }}
+      {{ $target = (printf "target=\"_blank\" rel=\"%s\"" $rel) }}
     {{ end }}
     <li>
       <a href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }} aria-label="{{ .icon }}"

--- a/modules/wowchemy/layouts/partials/blocks/contact.html
+++ b/modules/wowchemy/layouts/partials/blocks/contact.html
@@ -144,7 +144,8 @@
     {{ if not $scheme }}
       {{ $link = .link | relLangURL }}
     {{ else if in (slice "http" "https") $scheme }}
-      {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
+      {{ $rel := .custom_rel | default "noopener" }}
+      {{ $target = (printf "target=\"_blank\" rel=\"%s\"" $rel) }}
     {{ end }}
     <li>
       <i class="fa-li {{ $pack }} {{ $pack_prefix }}-{{ .icon }} fa-2x" aria-hidden="true"></i>

--- a/modules/wowchemy/layouts/partials/blocks/v1/about.avatar.html
+++ b/modules/wowchemy/layouts/partials/blocks/v1/about.avatar.html
@@ -71,7 +71,8 @@
       {{ $link = .link | relLangURL }}
       {{ if eq (path.Ext $link) ".pdf" }}{{ $target = "target=\"_blank\" rel=\"noopener\"" }}{{ end }}
     {{ else if in (slice "http" "https") $scheme }}
-      {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
+      {{ $rel := .custom_rel | default "noopener" }}
+      {{ $target = (printf "target=\"_blank\" rel=\"%s\"" $rel) }}
     {{ end }}
     <li>
       <a href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }} aria-label="{{ .icon }}"

--- a/modules/wowchemy/layouts/partials/blocks/v1/about.html
+++ b/modules/wowchemy/layouts/partials/blocks/v1/about.html
@@ -73,7 +73,8 @@
         {{ if not $scheme }}
           {{ $link = .link | relLangURL }}
         {{ else if in (slice "http" "https") $scheme }}
-          {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
+          {{ $rel := .custom_rel | default "noopener" }}
+          {{ $target = (printf "target=\"_blank\" rel=\"%s\"" $rel) }}
         {{ end }}
         <li>
           <a href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }} aria-label="{{ .icon }}">

--- a/modules/wowchemy/layouts/partials/blocks/v1/contact.html
+++ b/modules/wowchemy/layouts/partials/blocks/v1/contact.html
@@ -145,7 +145,8 @@
     {{ if not $scheme }}
       {{ $link = .link | relLangURL }}
     {{ else if in (slice "http" "https") $scheme }}
-      {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
+      {{ $rel := .custom_rel | default "noopener" }}
+      {{ $target = (printf "target=\"_blank\" rel=\"%s\"" $rel) }}
     {{ end }}
     <li>
       <i class="fa-li {{ $pack }} {{ $pack_prefix }}-{{ .icon }} fa-2x" aria-hidden="true"></i>

--- a/starters/academic/content/_index.md
+++ b/starters/academic/content/_index.md
@@ -269,6 +269,13 @@ sections:
           icon_pack: fas
           name: Zoom Me
           link: 'https://zoom.com'
+        # Link to your mastodon profile. By specifying rel="me" you can verify this site in your mastodon metadata.
+        # Use custom_rel to set the rel attribute to a custom value, e.g. 'noopener me'
+        # See also https://docs.joinmastodon.org/user/profile/#verification
+        - icon: mastodon
+          icon_pack: fab
+          link: https://mastodon.example.com/@username
+          custom_rel: 'noopener me'
       # Automatically link email and phone or display as text?
       autolink: true
       # Email form provider

--- a/starters/academic/content/authors/admin/_index.md
+++ b/starters/academic/content/authors/admin/_index.md
@@ -66,6 +66,13 @@ social:
   - icon: linkedin
     icon_pack: fab
     link: https://www.linkedin.com/
+  # Link to your mastodon profile. By specifying rel="me" you can verify this site in your mastodon metadata.
+  # Use custom_rel to set the rel attribute to a custom value, e.g. 'noopener me'
+  # See also https://docs.joinmastodon.org/user/profile/#verification
+  - icon: mastodon
+    icon_pack: fab
+    link: https://mastodon.example.com/@username
+    custom_rel: 'noopener me'
   # Link to a PDF of your resume/CV.
   # To use: copy your resume to `static/uploads/resume.pdf`, enable `ai` icons in `params.yaml`,
   # and uncomment the lines below.

--- a/starters/blog/content/authors/admin/_index.md
+++ b/starters/blog/content/authors/admin/_index.md
@@ -51,6 +51,13 @@ social:
   - icon: instagram
     icon_pack: fab
     link: https://instagram.com/geocushen
+  # Link to your mastodon profile. By specifying rel="me" you can verify this site in your mastodon metadata.
+  # Use custom_rel to set the rel attribute to a custom value, e.g. 'noopener me'
+  # See also https://docs.joinmastodon.org/user/profile/#verification
+  - icon: mastodon
+    icon_pack: fab
+    link: https://mastodon.example.com/@username
+    custom_rel: 'noopener me'
 # Uncomment below for Github link
 #- icon: github
 #  icon_pack: fab

--- a/starters/minimal/content/authors/admin/_index.md
+++ b/starters/minimal/content/authors/admin/_index.md
@@ -47,6 +47,13 @@ social:
   - icon: github
     icon_pack: fab
     link: https://github.com/gcushen
+  # Link to your mastodon profile. By specifying rel="me" you can verify this site in your mastodon metadata.
+  # Use custom_rel to set the rel attribute to a custom value, e.g. 'noopener me'
+  # See also https://docs.joinmastodon.org/user/profile/#verification
+  - icon: mastodon
+    icon_pack: fab
+    link: https://mastodon.example.com/@username
+    custom_rel: 'noopener me'
   # Link to a PDF of your resume/CV from the About widget.
   # To enable, copy your resume/CV to `static/uploads/resume.pdf`
   - icon: file-pdf

--- a/starters/research-group/content/authors/admin/_index.md
+++ b/starters/research-group/content/authors/admin/_index.md
@@ -50,6 +50,13 @@ social:
   - icon: github
     icon_pack: fab
     link: https://github.com/gcushen
+  # Link to your mastodon profile. By specifying rel="me" you can verify this site in your mastodon metadata.
+  # Use custom_rel to set the rel attribute to a custom value, e.g. 'noopener me'
+  # See also https://docs.joinmastodon.org/user/profile/#verification
+  - icon: mastodon
+    icon_pack: fab
+    link: https://mastodon.example.com/@username
+    custom_rel: 'noopener me'
 # Link to a PDF of your resume/CV from the About widget.
 # To enable, copy your resume/CV to `static/files/cv.pdf` and uncomment the lines below.
 # - icon: cv


### PR DESCRIPTION
### Purpose
Allow the user to specify a custom rel tag for social links while still using 'noopener' as default.
This could be used e.g. to specify rel="me" for a link to a mastodon profile to verify the site as described in the [mastodon documentation](https://docs.joinmastodon.org/user/profile/#verification).

Resolves #2880
