### PR TITLE
Fix table class name in fixHugoOutput

### DIFF
--- a/modules/wowchemy/assets/js/wowchemy.js
+++ b/modules/wowchemy/assets/js/wowchemy.js
@@ -83,7 +83,7 @@ function fixHugoOutput() {
   $("input[type='checkbox'][disabled]").parents('ul').addClass('task-list');
 
   // Bootstrap table style is opt-in and Goldmark doesn't add it.
-  $('table').addClass('.table');
+  $('table').addClass('table');
 }
 
 // Get an element's siblings.


### PR DESCRIPTION
### Purpose

The addClass call must be called with class name only instead of '.table' as class name.
Previously this lead to undesirable behavior because markdown tables would be rendered without the proper CSS classes (see screenshots below).
Since I only noticed this problem just now, I did not create an issue so far.

### Screenshots
Old behavior:
![grafik](https://user-images.githubusercontent.com/1130491/209700869-cff7bbfe-4698-4b55-aca2-47fb02bb16b6.png)
New behavior:
![grafik](https://user-images.githubusercontent.com/1130491/209700926-66f45389-b070-4a00-864f-b5797e048949.png)

