### PR TITLE
feat: automatic numbering of publications (fix #1598)

### DIFF
--- a/modules/wowchemy/assets/js/wowchemy-publication.js
+++ b/modules/wowchemy/assets/js/wowchemy-publication.js
@@ -17,6 +17,52 @@ let filterValues;
 // Publication container.
 let $grid_pubs = $('#container-publications');
 
+// Function to update the numbering of items
+function update_number_items() {
+  let index_item_visible = 1;
+
+  for (let i_item = 0; i_item < $grid_pubs[0].childElementCount; i_item++) {
+    let $this_element_i = document.getElementById('container-publications').children[i_item];
+
+    let searchResults = searchRegex ? $($this_element_i).text().match(searchRegex) : true;
+    let filterResults = filterValues ? $($this_element_i).is(filterValues) : true;
+
+    if (searchResults && filterResults) {
+      $($this_element_i.children[0].children[0]).text(index_item_visible);
+      index_item_visible++;
+    }
+  }
+}
+
+// Function to update the numbering of items
+function update_number_items_reverse() {
+  let index_item_visible = 0;
+
+  for (let i_item = 0; i_item < $grid_pubs[0].childElementCount; i_item++) {
+    let $this_element_i = document.getElementById('container-publications').children[i_item];
+
+    let searchResults = searchRegex ? $($this_element_i).text().match(searchRegex) : true;
+    let filterResults = filterValues ? $($this_element_i).is(filterValues) : true;
+
+    index_item_visible += searchResults && filterResults;
+  }
+  let total_number_visible_index = index_item_visible;
+
+  index_item_visible = 1;
+
+  for (let i_item = 0; i_item < $grid_pubs[0].childElementCount; i_item++) {
+    let $this_element_i = document.getElementById('container-publications').children[i_item];
+
+    let searchResults = searchRegex ? $($this_element_i).text().match(searchRegex) : true;
+    let filterResults = filterValues ? $($this_element_i).is(filterValues) : true;
+
+    if (searchResults && filterResults) {
+      $($this_element_i.children[0].children[0]).text(total_number_visible_index - index_item_visible + 1);
+      index_item_visible++;
+    }
+  }
+}
+
 // Initialise Isotope publication layout if required.
 if ($grid_pubs.length) {
   $grid_pubs.isotope({
@@ -38,6 +84,7 @@ if ($grid_pubs.length) {
   let $quickSearch = $('.filter-search').keyup(
     debounce(function () {
       searchRegex = new RegExp($quickSearch.val(), 'gi');
+      update_number_items();
       $grid_pubs.isotope();
     }),
   );
@@ -55,6 +102,7 @@ if ($grid_pubs.length) {
     filterValues = concatValues(pubFilters);
 
     // Activate filters.
+    update_number_items();
     $grid_pubs.isotope();
 
     // If filtering by publication type, update the URL hash to enable direct linking to results.
@@ -115,6 +163,7 @@ function filter_publications() {
   filterValues = concatValues(pubFilters);
 
   // Activate filters.
+  update_number_items();
   $grid_pubs.isotope();
 
   // Set selected option.

--- a/modules/wowchemy/layouts/partials/views/citation.html
+++ b/modules/wowchemy/layouts/partials/views/citation.html
@@ -2,6 +2,7 @@
 {{ $has_attachments := partial "functions/has_attachments" $item }}
 
 <div class="pub-list-item view-citation" style="margin-bottom: 1rem">
+  <span>{{- add 1 .index -}}</span>.
   <i class="far fa-file-alt pub-icon" aria-hidden="true"></i>
 
   {{/* APA Style */}}


### PR DESCRIPTION
### Purpose

Thanks for this theme, it is very useful!

As other people have said in #1598, it would be very nice if it was possible to have the publications numbered in the publication list.

This PR implements an automatic numbering of publications (either in the normal or in the reverse sense).
This is done by a new JS function `update_number_items()` which is called before `isotope()`.
To get the reverse order, we just have to change the call and use instead the new function `update_number_items_reverse()`.

### Screenshots

#### Before:

![screenshot_before](https://user-images.githubusercontent.com/9538132/215450785-3e0392bd-d04d-4001-a8cc-3f14ad26fe69.jpg)

#### After (with normal order) :

![screenshot_after](https://user-images.githubusercontent.com/9538132/215450838-cad840a2-c59f-44ad-be58-643bac5a8df1.jpg)

#### After (with reverse order) :

![screenshot_after_reverse](https://user-images.githubusercontent.com/9538132/215450971-cafbbc43-8520-44e5-979b-ff7268aa8e58.jpg)

