### PR TITLE
Fix Shortcode context for v2 blocks

### DIFF
--- a/modules/wowchemy/layouts/partials/blocks/about.avatar.html
+++ b/modules/wowchemy/layouts/partials/blocks/about.avatar.html
@@ -82,7 +82,7 @@
     {{ end }}
   </ul>
 
-  {{ with ($block.content.text | emojify | markdownify) | default $person_page.Content }}
+  {{ with ($block.content.text | emojify | $page.RenderString) | default $person_page.Content }}
   <div class="article-style pt-2 d-flex justify-content-center">
     <div class="bio-text">
       {{ . }}

--- a/modules/wowchemy/layouts/partials/blocks/accomplishments.html
+++ b/modules/wowchemy/layouts/partials/blocks/accomplishments.html
@@ -9,7 +9,7 @@
 
 <!-- Accomplishments widget -->
 <div class="col-12 {{if eq $columns "2"}}col-lg-8{{end}}">
-  {{ with $block.Content }}{{ . }}{{ end }}
+  {{ with $block.content.text }}{{ . | emojify | $page.RenderString }}{{ end }}
 
   {{ if $block.content.items }}
   {{ range $idx, $key := sort $block.content.items ".date_start" "desc" }}

--- a/modules/wowchemy/layouts/partials/blocks/collection.html
+++ b/modules/wowchemy/layouts/partials/blocks/collection.html
@@ -78,7 +78,7 @@
 
 <div class="col-12 {{if eq $columns "2"}}col-lg-8{{end}}">
 
-  {{ with $block.content.text }}{{ . | emojify | markdownify }}{{ end }}
+  {{ with $block.content.text }}{{ . | emojify | $page.RenderString }}{{ end }}
 
   {{ range $index, $item := $query }}
     {{ partial "functions/render_view" (dict "page" $block "item" . "view" ($block.design.view | default "compact") "index" $index) }}

--- a/modules/wowchemy/layouts/partials/blocks/contact.html
+++ b/modules/wowchemy/layouts/partials/blocks/contact.html
@@ -24,7 +24,7 @@
 {{ end }}
 
 <div class="col-12 {{if eq $columns "2"}}col-lg-8{{end}}">
-  {{ with $block.content.text }}{{ . }}{{ end }}
+  {{ with $block.content.text }}{{ . | emojify | $page.RenderString }}{{ end }}
 
   {{ if $use_form }}
 

--- a/modules/wowchemy/layouts/partials/blocks/experience.html
+++ b/modules/wowchemy/layouts/partials/blocks/experience.html
@@ -9,7 +9,7 @@
 
 <!-- Experience widget -->
 <div class="col-12 {{if eq $columns "2"}}col-lg-8{{end}}">
-  {{ with $block.content.text }}{{ . | emojify | markdownify }}{{ end }}
+  {{ with $block.content.text }}{{ . | emojify | $page.RenderString }}{{ end }}
 
   {{ if $block.content.items }}
   {{ $exp_len := len $block.content.items }}

--- a/modules/wowchemy/layouts/partials/blocks/features.html
+++ b/modules/wowchemy/layouts/partials/blocks/features.html
@@ -16,7 +16,7 @@
 
   {{ with $block.content.text }}
   <div class="col-md-12">
-    {{ . | emojify | markdownify }}
+    {{ . | emojify | $page.RenderString }}
   </div>
   {{ end }}
 

--- a/modules/wowchemy/layouts/partials/blocks/hero.html
+++ b/modules/wowchemy/layouts/partials/blocks/hero.html
@@ -17,7 +17,7 @@
     {{ end }}
 
     {{ with $block.content.text }}
-      <div class="hero-lead">{{ . | markdownify | emojify }}</div>
+      <div class="hero-lead">{{ . | $page.RenderString | emojify }}</div>
     {{ end }}
 
     {{/* Call-to-action link */}}

--- a/modules/wowchemy/layouts/partials/blocks/markdown.html
+++ b/modules/wowchemy/layouts/partials/blocks/markdown.html
@@ -6,7 +6,7 @@
 {{ $page := .wcPage }}
 {{ $block := .wcBlock }}
 {{ $columns := $block.design.columns | default "1" }}
-{{ $text := $block.content.text | emojify | markdownify }}
+{{ $text := $block.content.text | emojify | $page.RenderString }}
 
 {{ if ne $columns "1" }}
   <div class="col-12 col-lg-8">

--- a/modules/wowchemy/layouts/partials/blocks/portfolio.html
+++ b/modules/wowchemy/layouts/partials/blocks/portfolio.html
@@ -13,7 +13,7 @@
 
 <div class="col-12 {{if eq $columns "2"}}col-lg-8{{end}}">
 
-  {{ with $block.content.text }}{{ . | markdownify }}{{ end }}
+  {{ with $block.content.text }}{{ . | $page.RenderString | emojify }}{{ end }}
 
   {{ if $block.content.buttons }}
 

--- a/modules/wowchemy/layouts/partials/blocks/tag_cloud.html
+++ b/modules/wowchemy/layouts/partials/blocks/tag_cloud.html
@@ -23,7 +23,7 @@
 {{ $columns := $block.design.columns | default "1" }}
 
 <div class="col-12 {{if eq $columns "2"}}col-lg-8{{else}}text-center{{end}}">
-  {{ with $block.content.text }}{{ . | markdownify }}{{ end }}
+  {{ with $block.content.text }}{{ . | $page.RenderString | emojify }}{{ end }}
 
   {{ if ne $count 0 }}
 


### PR DESCRIPTION
### Purpose

Shortcodes in the new block system do not get access to the correct `.Page` variable (see #2918 ). The problem is the use of `markdownify` function to parse `$block.content.text`, since it actually is an alias to `site.Home.RenderString` since v 0.93.0 (see https://github.com/gohugoio/hugo/issues/9959#issuecomment-1142610699). 

This causes the shortcodes to always get the Homepage as `.Page` variable. The fix is to substitute `markdownify` with `$page.RenderString`, which gives the correct context.

An actual example of this behaviour can be found in [this branch](https://github.com/Agos95/wowchemy-hugo-themes/tree/getCSV-test) (in the `csv` page):

![screenshot_2023-02-11_16-46](https://user-images.githubusercontent.com/43784886/218267439-cdd23574-9189-4528-a078-9f7208d36012.png)
![screenshot_2023-02-11_16-46_1](https://user-images.githubusercontent.com/43784886/218267444-a922420b-2b70-4c54-9669-8a08d4fefd35.png)

This PR fixes #2918.