### PR TITLE
Fix Sticky Header option

### DIFF
--- a/modules/wowchemy/layouts/partials/site_js.html
+++ b/modules/wowchemy/layouts/partials/site_js.html
@@ -159,13 +159,13 @@
 
 {{/* by default don't use Headroom in homepage and book layout */}}
 {{ $use_headroom := not (.IsHome | or (eq .Type "book")) }}
-{{/* support for old "wrong" syntax */}}
-{{ if (isset $.Params "header.on_scroll") }}
-  {{ $use_headroom = false }}
-{{ end }}
 {{/* look global site parameter 'header.sticky' true/false */}}
 {{ if (isset site.Params.header "sticky") }}
   {{ $use_headroom = not site.Params.header.sticky }}
+{{ end }}
+{{/* support for old "buggy" syntax "header.on_scroll" in page parameters */}}
+{{ if (isset $.Params "header.on_scroll") }}
+  {{ $use_headroom = false }}
 {{ end }}
 {{/* look page parameter 'header.sticky' true/false */}}
 {{ if (isset $.Params.header "sticky") }}

--- a/modules/wowchemy/layouts/partials/site_js.html
+++ b/modules/wowchemy/layouts/partials/site_js.html
@@ -127,11 +127,52 @@
 {{ end }}
 
 {{/* Page Data */}}
-{{ $default_headroom := not (.IsHome | or (eq .Type "book")) }}
-{{ $use_headroom := cond (isset $.Params "header.on_scroll") (eq $.Params.header.on_scroll "disappear") (default $default_headroom) }}
-{{ printf "<script id=\"page-data\" type=\"application/json\">%s</script>" (dict "use_headroom" $use_headroom | jsonify) | safeHTML}}
 
 {{/* Headroom */}}
+{{/*
+  Loading the Headroom js set the header to disappear when scrolling the page down.
+  So to have a sticky header, don't load the Headroom.
+  This option can be set in the following ways:
+    - globally, by adding in your 'params.yaml':
+      ```
+      header:
+        sticky: true/false
+      ```
+
+    - per page, by adding in the page Front Matter:
+      ```
+      header:
+        sticky: true/false
+      ```
+
+    - in order to be compatible with older versions where there was a bug, Headroom
+      is also disabled by setting in the page Front Matter (this is now deprecated)
+      ```
+      header.on_scroll: false
+      ```
+  'false' indicates that the header disappears on scrolling (-> load Headroom)
+  'true'  indicates that the header is sticky (-> don't load Headroom)
+
+  By default, the header is sticky in the homepage and in the book layout,
+  and disappears on scrolling in all other pages.
+*/}}
+
+{{/* by default don't use Headroom in homepage and book layout */}}
+{{ $use_headroom := not (.IsHome | or (eq .Type "book")) }}
+{{/* support for old "wrong" syntax */}}
+{{ if (isset $.Params "header.on_scroll") }}
+  {{ $use_headroom = false }}
+{{ end }}
+{{/* look global site parameter 'header.sticky' true/false */}}
+{{ if (isset site.Params.header "sticky") }}
+  {{ $use_headroom = not site.Params.header.sticky }}
+{{ end }}
+{{/* look page parameter 'header.sticky' true/false */}}
+{{ if (isset $.Params.header "sticky") }}
+  {{ $use_headroom = not $.Params.header.sticky }}
+{{ end }}
+{{ printf "<script id=\"page-data\" type=\"application/json\">%s</script>" (dict "use_headroom" $use_headroom | jsonify) | safeHTML}}
+
 {{ if $use_headroom }}
   {{ $headroom := resources.Get "js/wowchemy-headroom.js" | js.Build (dict "format" "esm" "minify" true) }}
   {{- if hugo.IsProduction -}}


### PR DESCRIPTION
### Purpose

This PR fixes the option to have a sticky header (following [this discussion](https://discord.com/channels/722225264733716590/1079780161836286124) on Discord). 

The bug is here: https://github.com/wowchemy/wowchemy-hugo-themes/blob/ff4b7b1193fa7770be486f4659a051be71149f2f/modules/wowchemy/layouts/partials/site_js.html#L131
In fact, instead of looking at
```yaml
---
header:
  on_scroll:
---
```
actually the code searches for 
```yaml
---
header.on_scroll: 
---
```

The PR introduces the following changes:
- use the keyword `sticky` instead of `on_scroll`, which in my opinion is more clear.
- search for 
  ```yaml
  ---
  header:
    sticky: true/false
  ---
  ```
  option to configure the header. Before, the value was set to `"disappear"` to have a disappearing header, while everything else created a sticky header. The use of `true/false` instead should be more clear.
- possibility to set a global behaviour using the `params.yaml` configuration file, or a per page one by using the single page Front Matter.
- backward compatibility with the old "buggy" way to set the sticky header with `"header.on_scroll"`

The logic to set the behaviour of the header is:
- by default homepage and book layout have a sticky header and all other pages have a disappearing one
- use the global configuration in `params.yaml` to set the options to the whole site:
```yaml
header:
  sticky: true/false
```
- use the specific page option, by looking the front matter:
```yaml
---
header:
  sticky: true/false

# or this one for backword compatibility
#header.on_scroll: 
---
```

### Documentation

[This section](https://wowchemy.com/docs/getting-started/customization/#header) in the documentation should be update by describing the option to have a sticky header. In my opinio, this should mention:
- the default behaviour
- the global configuration in `params.yaml`
- the single page configuration using front matter
- a warning callout to describe the buggy behaviour in previous versions
- the possibility to use Hugo cascade to set the header sticky or not only for some subsets of pages
