### PR TITLE
Fix gallery in Chrome

### DIFF
--- a/modules/wowchemy/assets/scss/wowchemy/elements/_media.scss
+++ b/modules/wowchemy/assets/scss/wowchemy/elements/_media.scss
@@ -126,6 +126,7 @@ svg {
   transition: transform 0.3s ease-in-out;
   cursor: zoom-in;
   counter-increment: item-counter;
+  overflow: hidden;
 
   a {
     z-index: 1;


### PR DESCRIPTION
### Purpose

Fix Gallery in Chrome.

### Screenshots

This is the gallery in Chrome:

![gallery-in-chrome](https://user-images.githubusercontent.com/33870216/229967315-ecc772de-e993-4f0f-9c38-dd2cafc4bb96.png)

This is the gallery in Firefox:

![gallery-in-firefox](https://user-images.githubusercontent.com/33870216/229967368-55a14d32-ce54-4ce6-b3cc-4aadd50e76d7.png)

### Documentation

Overriding a flexbox default setting as described in this [StackOverflow post](https://stackoverflow.com/questions/36247140/why-dont-flex-items-shrink-past-content-size). Firefox seems to handle it correctly.

Edit.

I found a [WICG post](https://github.com/WICG/view-transitions/blob/main/debugging_overflow_on_images.md) where they are talking about this issue.
