### PR TITLE
Fix list_children.html shortcode

### DIFF
--- a/modules/wowchemy/layouts/shortcodes/list_children.html
+++ b/modules/wowchemy/layouts/shortcodes/list_children.html
@@ -7,7 +7,7 @@
         If "true", show also the summary in addition to the title.
 */}}
 
-{{ $show_summary := ne (.Get "show_summary") "false" }}
+{{ $show_summary := .Get "show_summary" | default false }}
 {{ if gt (len $.Page.Pages) 0}}
   <ul class="list-unstyled">
     {{ range $.Page.Pages }}


### PR DESCRIPTION
This small change makes the `list_children` shortcode to actually follow its description, where `$show_summary` should be false by default. Triggered by [this Discord message](https://discord.com/channels/722225264733716590/1100509629680721930/1100509629680721930).