### PR TITLE
Fix `last_children` shortcode comment

### DIFF
--- a/modules/wowchemy/layouts/shortcodes/list_children.html
+++ b/modules/wowchemy/layouts/shortcodes/list_children.html
@@ -3,7 +3,7 @@
 
     Parameters
     ----------
-    show_summary : bool, default "false"
+    show_summary : bool, default "true"
         If "true", show also the summary in addition to the title.
 */}}
 


### PR DESCRIPTION
### Purpose

Small fix to the comment of the `last_children` shortcode (the default is to show the summary), as pointed out in #2938.

