### PR TITLE
fix: GitHub deprecated GH Actions Node version

### DIFF
--- a/.github/workflows/split-packages.yaml
+++ b/.github/workflows/split-packages.yaml
@@ -41,7 +41,7 @@ jobs:
 
       # step if no tag is pushed
       - if: "!startsWith(github.ref, 'refs/tags/')"
-        uses: "symplify/monorepo-split-github-action@2.3"
+        uses: "symplify/monorepo-split-github-action@2.3.0"
         with:
           # ↓ split "packages/<package-name><package-name>" directory
           package_directory: 'starters/${{ matrix.package.local_path }}'


### PR DESCRIPTION
### Purpose

Describe the purpose of this change. If there is an existing issue that is resolved by this pull request, please reference it in the form `Fixes #1234` where 1234 is the relevant issue number.

### Screenshots

If this is a GUI change, try to include screenshots of the change. If not, please delete this section.

### Documentation

If this is an enhancement, add a link here to the corresponding pull request on https://github.com/sourcethemes/academic-www or describe the documentation changes necessary.
