### PR TITLE
fix: exclude PNG from lossy webp compression

### DIFF
--- a/modules/wowchemy/layouts/_default/_markup/render-image.html
+++ b/modules/wowchemy/layouts/_default/_markup/render-image.html
@@ -29,7 +29,8 @@
       {{- if $img -}}
         {{- $isSVG := eq $img.MediaType.SubType "svg" -}}
         {{- $isGIF := eq $img.MediaType.SubType "gif" -}}
-        {{- if $isSVG | or $isGIF -}}
+        {{- $isPNG := eq $img.MediaType.SubType "png" -}}
+        {{- if $isSVG | or $isGIF | or $isPNG -}}
           <img alt="{{ $alt }}"
            src="{{ $img.RelPermalink }}"
            loading="lazy"

--- a/modules/wowchemy/layouts/shortcodes/figure.html
+++ b/modules/wowchemy/layouts/shortcodes/figure.html
@@ -70,7 +70,8 @@
       {{- if $img -}}
         {{- $isSVG := eq $img.MediaType.SubType "svg" -}}
         {{- $isGIF := eq $img.MediaType.SubType "gif" -}}
-        {{- if $isSVG | or $isGIF -}}
+        {{- $isPNG := eq $img.MediaType.SubType "png" -}}
+        {{- if $isSVG | or $isGIF | or $isPNG -}}
           <img alt="{{ $alt }}"
            src="{{ $img.RelPermalink }}"
            loading="lazy"


### PR DESCRIPTION
### Purpose

Hugo uses a lossy compression when WebP is specified. That makes PNG
images such as a screenshot blurry.

```
$ identify content/post/.../myimage.png
-> PNG 738x607 738x607+0+0 8-bit sRGB 118157B 0.000u 0:00.000

$ webpinfo docs/post/.../myimage_..._1200x1200_fit_q75_h2_lanczos_3.webp \
    | egrep 'Height:|Width:|Format:'
->
  Width: 738
  Height: 607
  Format: Lossy (1)
```

Exclude those PNGs from a conversion and use the original lossless files
as is alongside of SVG or GIF.