### PR TITLE
Slider block: only show controls/indicators if >1 slides are defined.

### DIFF
--- a/modules/wowchemy/layouts/partials/blocks/slider.html
+++ b/modules/wowchemy/layouts/partials/blocks/slider.html
@@ -6,13 +6,16 @@
 {{ $page := .wcPage }}
 {{ $block := .wcBlock }}
 {{ $hash_id := .wcIdentifier }}
+{{ $slide_count := len $block.content.slides }}
 
 <!-- Indicators -->
+{{ if gt $slide_count 1 }}
 <ol class="carousel-indicators">
   {{ range $index, $item := $block.content.slides }}
   <li data-target="#{{$hash_id}}" data-slide-to="{{$index}}" {{if eq $index 0}}class="active"{{end}}></li>
   {{ end }}
 </ol>
+{{ end }}
 
 <!-- Carousel slides wrapper -->
 <div class="carousel-inner">
@@ -81,6 +84,7 @@
 </div>
 
 <!-- Left and right controls -->
+{{ if gt $slide_count 1 }}
 <a class="carousel-control-prev" href="#{{$hash_id}}" data-slide="prev">
   <span class="carousel-control-prev-icon"></span>
   <span class="sr-only">Previous</span>
@@ -89,3 +93,4 @@
   <span class="carousel-control-next-icon"></span>
   <span class="sr-only">Next</span>
 </a>
+{{ end }}

--- a/modules/wowchemy/layouts/partials/blocks/v1/slider.html
+++ b/modules/wowchemy/layouts/partials/blocks/v1/slider.html
@@ -6,13 +6,16 @@
 {{ $page := .wcPage }}
 {{ $block := .wcBlock }}
 {{ $hash_id := .wcIdentifier }}
+{{ $slide_count := len $block.Params.content.slides }}
 
 <!-- Indicators -->
+{{ if gt $slide_count 1 }}
 <ol class="carousel-indicators">
   {{ range $index, $item := $block.Params.content.slides }}
   <li data-target="#{{$hash_id}}" data-slide-to="{{$index}}" {{if eq $index 0}}class="active"{{end}}></li>
   {{ end }}
 </ol>
+{{ end }}
 
 <!-- Carousel slides wrapper -->
 <div class="carousel-inner">
@@ -75,6 +78,7 @@
 </div>
 
 <!-- Left and right controls -->
+{{ if gt $slide_count 1 }}
 <a class="carousel-control-prev" href="#{{$hash_id}}" data-slide="prev">
   <span class="carousel-control-prev-icon"></span>
   <span class="sr-only">Previous</span>
@@ -83,3 +87,4 @@
   <span class="carousel-control-next-icon"></span>
   <span class="sr-only">Next</span>
 </a>
+{{ end }}


### PR DESCRIPTION
### Purpose

The slider block shows slide switching controls/indicators even when only one slide is defined. This change makes showing those conditional on the number of defined slides. 

This is related to https://github.com/wowchemy/wowchemy-hugo-themes/issues/2129
