### PR TITLE
Add support for custom social icon svg's in the about.biography block

### DIFF
--- a/modules/wowchemy/layouts/partials/blocks/about.biography.html
+++ b/modules/wowchemy/layouts/partials/blocks/about.biography.html
@@ -75,20 +75,20 @@
         {{ else if in (slice "http" "https") $scheme }}
           {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
         {{ end }}
-          <li>
-            <a href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }} aria-label="{{ .icon }}">
-              {{ with .icon }}
-                {{- if eq $pack "custom" -}}
-                  {{- $svg_icon := resources.Get (printf "media/icons/%s.svg" .) -}}
-                  {{- if $svg_icon -}}
-                    <img src="{{ $svg_icon.RelPermalink }}" alt="{{.}}" class="fa bigicon" loading="lazy" style="height:2rem" >
-                  {{- end -}}
-                  {{- else -}}
-                  <i class="{{ $pack }} {{ $pack_prefix }}-{{ . }} big-icon"></i>
+        <li>
+          <a href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }} aria-label="{{ .icon }}">
+            {{ with .icon }}
+              {{- if eq $pack "custom" -}}
+                {{- $svg_icon := resources.Get (printf "media/icons/%s.svg" .) -}}
+                {{- if $svg_icon -}}
+                  <img src="{{ $svg_icon.RelPermalink }}" alt="{{.}}" class="fa bigicon" loading="lazy" style="height:2rem" >
                 {{- end -}}
-              {{ end }}
-            </a>
-          </li>
+              {{- else -}}
+                <i class="{{ $pack }} {{ $pack_prefix }}-{{ . }} big-icon"></i>
+              {{- end -}}
+            {{ end }}
+          </a>
+        </li>
         {{ end }}
       </ul>
 

--- a/modules/wowchemy/layouts/partials/blocks/about.biography.html
+++ b/modules/wowchemy/layouts/partials/blocks/about.biography.html
@@ -75,11 +75,20 @@
         {{ else if in (slice "http" "https") $scheme }}
           {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
         {{ end }}
-        <li>
-          <a href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }} aria-label="{{ .icon }}">
-            <i class="{{ $pack }} {{ $pack_prefix }}-{{ .icon }} big-icon"></i>
-          </a>
-        </li>
+          <li>
+            <a href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }} aria-label="{{ .icon }}">
+              {{ with .icon }}
+                {{- if eq $pack "custom" -}}
+                  {{- $svg_icon := resources.Get (printf "media/icons/%s.svg" .) -}}
+                  {{- if $svg_icon -}}
+                    <img src="{{ $svg_icon.RelPermalink }}" alt="{{.}}" class="fa bigicon" loading="lazy" style="height:2rem" >
+                  {{- end -}}
+                  {{- else -}}
+                  <i class="{{ $pack }} {{ $pack_prefix }}-{{ . }} big-icon"></i>
+                {{- end -}}
+              {{ end }}
+            </a>
+          </li>
         {{ end }}
       </ul>
 


### PR DESCRIPTION
### Purpose

This PR adds support for custom svg icons to the about.biography block in the same manner as the featurette widget using the "custom" icon pack.

The documentation for this feature is here: [https://wowchemy.com/docs/getting-started/page-builder/#icons](https://wowchemy.com/docs/getting-started/page-builder/#icons)

It's related to but not a complete solution for issue [1698](https://github.com/wowchemy/wowchemy-hugo-themes/issues/1698)

Please review and accept if this meets the projects requirements.