### PR TITLE
Update academicons

### DIFF
--- a/modules/wowchemy/data/assets.toml
+++ b/modules/wowchemy/data/assets.toml
@@ -63,9 +63,9 @@
 # CSS
 
 [css.academicons]
-  version = "1.9.2"
-  sri = "sha512-KlJCpRsLf+KKu2VQa5vmRuClRFjxc5lXO03ixZt82HZUk41+1I0bD8KBSA0fY290ayMfWYI9udIqeOWSu1/uZg=="
-  url = "https://cdn.jsdelivr.net/npm/academicons@%s/css/academicons.min.css"
+  version = "1.9.4"
+  sri = "sha512-IW0nhlW5MgNydsXJO40En2EoCkTTjZhI3yuODrZIc8cQ4h1XcF53PsqDHa09NqnkXuIe0Oiyyj171BqZFwISBw=="
+  url = "https://cdn.jsdelivr.net/gh/jpswalsh/academicons@%s/css/academicons.min.css"
 [css.leaflet]
   version = "1.7.1"
   sri = ""  # Do NOT use SRI with dynamically generated files! More information: https://www.jsdelivr.com/using-sri-with-dynamic-files


### PR DESCRIPTION
Move from version 1.9.2 to version 1.9.4.

### Purpose
This provides the new arxiv icon among other updates.

### Screenshots

1.9.2
<img width="255" alt="Screenshot 2023-08-27 at 14 42 36" src="https://github.com/wowchemy/wowchemy-hugo-themes/assets/1614505/ec247714-a364-4abf-9000-8addc70d58f1">

1.9.4
<img width="256" alt="Screenshot 2023-08-27 at 14 42 53" src="https://github.com/wowchemy/wowchemy-hugo-themes/assets/1614505/0496024d-955f-4050-a204-1d6cb08e309d">


### Documentation
https://jpswalsh.github.io/academicons/
https://github.com/jpswalsh/academicons
https://www.jsdelivr.com/package/gh/jpswalsh/academicons
