### PR TITLE
Remove 'px' from width and height fields

### DIFF
--- a/modules/wowchemy/layouts/partials/blocks/accomplishments.html
+++ b/modules/wowchemy/layouts/partials/blocks/accomplishments.html
@@ -20,7 +20,7 @@
         <div class="d-flex align-content-start">
           <div class="mr-2 mb-2">
             {{- with .organization_url}}<a href="{{.}}" target="_blank" rel="noopener">{{end -}}
-            <img src="{{ $svg_icon.RelPermalink }}" width="56px" height="56px" alt="{{.organization | plainify}}" loading="lazy">
+            <img src="{{ $svg_icon.RelPermalink }}" width="56" height="56" alt="{{.organization | plainify}}" loading="lazy">
             {{- with .organization_url}}</a>{{end -}}
           </div>
           <div>

--- a/modules/wowchemy/layouts/partials/blocks/experience.html
+++ b/modules/wowchemy/layouts/partials/blocks/experience.html
@@ -42,7 +42,7 @@
           <div class="d-flex align-content-start">
             <div class="mr-2 mb-2">
               {{- with .company_url}}<a href="{{.}}" target="_blank" rel="noopener">{{end -}}
-              <img src="{{ $svg_icon.RelPermalink }}" width="56px" height="56px" alt="{{.company | plainify}}" loading="lazy">
+              <img src="{{ $svg_icon.RelPermalink }}" width="56" height="56" alt="{{.company | plainify}}" loading="lazy">
               {{- with .company_url}}</a>{{end -}}
             </div>
             <div>

--- a/modules/wowchemy/layouts/partials/blocks/v1/accomplishments.html
+++ b/modules/wowchemy/layouts/partials/blocks/v1/accomplishments.html
@@ -20,7 +20,7 @@
         <div class="d-flex align-content-start">
           <div class="mr-2 mb-2">
             {{- with .organization_url}}<a href="{{.}}" target="_blank" rel="noopener">{{end -}}
-            <img src="{{ $svg_icon.RelPermalink }}" width="56px" height="56px" alt="{{.organization | plainify}}" loading="lazy">
+            <img src="{{ $svg_icon.RelPermalink }}" width="56" height="56" alt="{{.organization | plainify}}" loading="lazy">
             {{- with .organization_url}}</a>{{end -}}
           </div>
           <div>

--- a/modules/wowchemy/layouts/partials/blocks/v1/experience.html
+++ b/modules/wowchemy/layouts/partials/blocks/v1/experience.html
@@ -42,7 +42,7 @@
           <div class="d-flex align-content-start">
             <div class="mr-2 mb-2">
               {{- with .company_url}}<a href="{{.}}" target="_blank" rel="noopener">{{end -}}
-              <img src="{{ $svg_icon.RelPermalink }}" width="56px" height="56px" alt="{{.company | plainify}}" loading="lazy">
+              <img src="{{ $svg_icon.RelPermalink }}" width="56" height="56" alt="{{.company | plainify}}" loading="lazy">
               {{- with .company_url}}</a>{{end -}}
             </div>
             <div>


### PR DESCRIPTION
### Purpose

According to the HTML standard, the `width` and `height` attributes of an `img` tag must specify the width/height in pixels *without* a unit. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img

This was wrong in these two places.
